### PR TITLE
Update Netlify redirects to 301 with force option

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -25,5 +25,5 @@
 [[redirects]]
   from = "/"
   to = "/en/"
-  status = 302
-  force = false
+  status = 301
+  force = true


### PR DESCRIPTION
This pull request includes the following changes:
- Adjusts the root redirect response to a 301 status.
- Enables the "force" option within Netlify redirects. 

No linked issues or additional changes were made.