### PR TITLE
Fix LinkedIn comment endpoint URL format

### DIFF
--- a/netlify/functions/lib/__tests__/linkedin-client.test.ts
+++ b/netlify/functions/lib/__tests__/linkedin-client.test.ts
@@ -90,7 +90,7 @@ describe('addComment', () => {
     await addComment(accessToken, personId, postUrn, 'Read more: https://example.com');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.linkedin.com/rest/comments',
+      `https://api.linkedin.com/rest/socialActions/${encodeURIComponent('urn:li:share:12345')}/comments`,
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({

--- a/netlify/functions/lib/linkedin-client.ts
+++ b/netlify/functions/lib/linkedin-client.ts
@@ -57,16 +57,19 @@ export async function addComment(
     message: { text },
   };
 
-  const response = await fetch(`${LINKEDIN_API}/comments`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-      'LinkedIn-Version': API_VERSION,
-      'X-Restli-Protocol-Version': '2.0.0',
-    },
-    body: JSON.stringify(body),
-  });
+  const response = await fetch(
+    `${LINKEDIN_API}/socialActions/${encodeURIComponent(postUrn)}/comments`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'LinkedIn-Version': API_VERSION,
+        'X-Restli-Protocol-Version': '2.0.0',
+      },
+      body: JSON.stringify(body),
+    }
+  );
 
   if (!response.ok) {
     const errorText = await response.text();


### PR DESCRIPTION
Update the LinkedIn comment endpoint to use the correct URL format for posting comments. This change ensures that the API calls are made to the appropriate endpoint, improving functionality.