### PR TITLE
Update LinkedIn post generation to instruct writing in first person

### DIFF
--- a/netlify/functions/lib/__tests__/linkedin-post-generator.test.ts
+++ b/netlify/functions/lib/__tests__/linkedin-post-generator.test.ts
@@ -74,6 +74,16 @@ describe('generateLinkedInPost', () => {
     expect(userPrompt).toContain(blogUrl);
   });
 
+  it('should instruct AI to write in first person', async () => {
+    vi.mocked(createClient).mockReturnValue({} as any);
+    vi.mocked(chat).mockResolvedValue(JSON.stringify({ post: 'Test post' }));
+
+    await generateLinkedInPost(sampleBlogContent, 'https://juanelojga.com/en/blog/test');
+
+    const systemPrompt = vi.mocked(chat).mock.calls[0][1];
+    expect(systemPrompt.toLowerCase()).toContain('first person');
+  });
+
   it('should enforce post length between 100 and 300 words via system prompt', async () => {
     vi.mocked(createClient).mockReturnValue({} as any);
     vi.mocked(chat).mockResolvedValue(JSON.stringify({ post: 'Short post' }));

--- a/netlify/functions/lib/linkedin-post-generator.ts
+++ b/netlify/functions/lib/linkedin-post-generator.ts
@@ -11,6 +11,7 @@ export interface BlogContent {
 const SYSTEM_PROMPT = `You are a LinkedIn post writer for a software engineer's personal brand.
 
 Write a LinkedIn post that summarizes the given blog post. Follow these rules:
+- Write in the FIRST person from the author's perspective (e.g., "I wrote...", "I explored...", "In my latest post I cover..."). Never refer to the author in the third person.
 - Length: between 100 and 300 words
 - Include the blog URL at the end of the post, right before the hashtags, on its own line
 - End with a discussion question to encourage engagement


### PR DESCRIPTION
Modify the LinkedIn post generation to require writing in the first person, enhancing the personal touch of the posts. Update tests to verify this new instruction.