### PR TITLE
Force OpenRouter research tool calls

### DIFF
--- a/scripts/__tests__/openrouter.test.ts
+++ b/scripts/__tests__/openrouter.test.ts
@@ -58,4 +58,29 @@ describe('OpenRouterClient', () => {
     expect(result.citations[0].url).toBe('https://example.com/news');
     expect(result.webSearchRequests).toBe(2);
   });
+
+  it('forces server tool execution when requested', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: '{"ok":true}' } }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      tools: [{ type: 'openrouter:web_search' }],
+      toolChoice: 'required',
+    });
+
+    const request = fetchMock.mock.calls[0][1];
+    const body = JSON.parse(String(request?.body));
+    expect(body.tool_choice).toBe('required');
+    expect(body.tools).toEqual([{ type: 'openrouter:web_search' }]);
+  });
 });

--- a/scripts/__tests__/research.test.ts
+++ b/scripts/__tests__/research.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { selectRandomStory, validateNewsCandidates, validateResearchBrief } from '../lib/research';
+import { describe, expect, it, vi } from 'vitest';
+import type { OpenRouterClient } from '../lib/openrouter';
+import {
+  discoverWeeklyNews,
+  researchSelectedStory,
+  selectRandomStory,
+  validateNewsCandidates,
+  validateResearchBrief,
+} from '../lib/research';
 import type { NewsCandidate, ResearchBrief } from '../lib/types';
 
 const now = new Date('2026-07-18T12:00:00.000Z');
@@ -107,5 +114,67 @@ describe('validateResearchBrief', () => {
 
     const citations = sources.map(source => ({ url: source.url, title: source.title }));
     expect(validateResearchBrief(brief, selected, citations, 3)).toEqual(brief);
+  });
+});
+
+describe('research tool execution', () => {
+  it('requires web search during weekly discovery', async () => {
+    const stories = [story(1), story(2), story(3), story(4)];
+    const completeJson = vi.fn().mockResolvedValue({
+      data: { stories },
+      citations: citationsFor(stories),
+      webSearchRequests: 1,
+    });
+    const client = { completeJson } as unknown as OpenRouterClient;
+
+    await discoverWeeklyNews(client, [], options, now);
+
+    expect(completeJson).toHaveBeenCalledWith(expect.objectContaining({ toolChoice: 'required' }));
+  });
+
+  it('requires server tools during deeper research', async () => {
+    const selected = story(1);
+    const sources = [
+      {
+        title: 'Primary announcement',
+        url: selected.sourceUrl,
+        publisher: 'Vendor',
+        sourceType: 'primary' as const,
+      },
+      {
+        title: 'Independent report',
+        url: 'https://report.example/story',
+        publisher: 'Reporter',
+        sourceType: 'reporting' as const,
+      },
+      {
+        title: 'Technical analysis',
+        url: 'https://analysis.example/story',
+        publisher: 'Analyst',
+        sourceType: 'analysis' as const,
+      },
+    ];
+    const brief: ResearchBrief = {
+      story: selected,
+      angle: 'A grounded engineering angle',
+      context: 'Verified context',
+      keyFacts: Array.from({ length: 5 }, (_, index) => ({
+        claim: `Fact ${index}`,
+        sourceUrls: [sources[index % sources.length].url],
+      })),
+      technicalImplications: ['Implication'],
+      openQuestions: ['Question'],
+      sources,
+    };
+    const completeJson = vi.fn().mockResolvedValue({
+      data: brief,
+      citations: sources.map(source => ({ url: source.url, title: source.title })),
+      webSearchRequests: 1,
+    });
+    const client = { completeJson } as unknown as OpenRouterClient;
+
+    await researchSelectedStory(client, selected, 3, now);
+
+    expect(completeJson).toHaveBeenCalledWith(expect.objectContaining({ toolChoice: 'required' }));
   });
 });

--- a/scripts/lib/openrouter.ts
+++ b/scripts/lib/openrouter.ts
@@ -16,6 +16,7 @@ interface CompletionOptions {
   systemPrompt: string;
   userPrompt: string;
   tools?: OpenRouterTool[];
+  toolChoice?: 'auto' | 'required' | 'none';
   temperature?: number;
   maxTokens?: number;
 }
@@ -74,6 +75,7 @@ export class OpenRouterClient {
         ],
         response_format: { type: 'json_object' },
         ...(options.tools?.length ? { tools: options.tools } : {}),
+        ...(options.tools?.length && options.toolChoice ? { tool_choice: options.toolChoice } : {}),
         temperature: options.temperature ?? 0.3,
         max_tokens: options.maxTokens ?? 8192,
       }),

--- a/scripts/lib/research.ts
+++ b/scripts/lib/research.ts
@@ -158,8 +158,13 @@ Return each story with: headline, summary, category (one of ${NEWS_CATEGORIES.jo
           },
         },
       ],
+      toolChoice: 'required',
       maxTokens: 5000,
     });
+
+    console.log(
+      `🔍 Discovery attempt ${attempt}: ${response.webSearchRequests} web search request(s), ${response.citations.length} citation(s)`
+    );
 
     try {
       if (response.webSearchRequests < 1) throw new Error('The model did not perform web search');
@@ -277,8 +282,13 @@ Return: story, angle, context, at least five keyFacts ({claim, sourceUrls}), tec
           },
         },
       ],
+      toolChoice: 'required',
       maxTokens: 8000,
     });
+
+    console.log(
+      `🔍 Research attempt ${attempt}: ${response.webSearchRequests} web search request(s), ${response.citations.length} citation(s)`
+    );
 
     try {
       if (response.webSearchRequests < 1)


### PR DESCRIPTION
## Summary

- force OpenRouter server-tool execution for weekly discovery and deeper research requests
- prevent the model from returning an ungrounded response without invoking web search
- log web-search request and citation counts for each attempt to make future workflow failures diagnosable
- add regression coverage for the serialized `tool_choice: "required"` request and both research call sites

## Root cause

[Generate Blog Post run 29654430006](https://github.com/juanelojga/juanelojga-webpage/actions/runs/29654430006) failed because OpenRouter server tools default to optional execution. The model returned twice without invoking `openrouter:web_search`, so the generator correctly rejected the ungrounded result.

## Validation

- [x] `pnpm test` — 40 files and 415 tests passed
- [x] `pnpm lint`
- [x] `pnpm exec prettier --check .`
- [x] `pnpm build` — 33 static pages generated
- [x] focused strict TypeScript check for generator modules
- [x] `git diff --check`

## Notes

A live OpenRouter generation still requires the repository secret and consumes credits. After merging, rerun the **Generate Blog Post** workflow manually to verify the external API path.