### PR TITLE
Accept cited OpenRouter research responses

### DIFF
--- a/scripts/__tests__/research.test.ts
+++ b/scripts/__tests__/research.test.ts
@@ -118,21 +118,22 @@ describe('validateResearchBrief', () => {
 });
 
 describe('research tool execution', () => {
-  it('requires web search during weekly discovery', async () => {
+  it('accepts cited weekly discovery when the usage counter is unavailable', async () => {
     const stories = [story(1), story(2), story(3), story(4)];
     const completeJson = vi.fn().mockResolvedValue({
       data: { stories },
       citations: citationsFor(stories),
-      webSearchRequests: 1,
+      webSearchRequests: 0,
     });
     const client = { completeJson } as unknown as OpenRouterClient;
 
     await discoverWeeklyNews(client, [], options, now);
 
     expect(completeJson).toHaveBeenCalledWith(expect.objectContaining({ toolChoice: 'required' }));
+    expect(completeJson).toHaveBeenCalledTimes(1);
   });
 
-  it('requires server tools during deeper research', async () => {
+  it('accepts cited deeper research when the usage counter is unavailable', async () => {
     const selected = story(1);
     const sources = [
       {
@@ -169,12 +170,13 @@ describe('research tool execution', () => {
     const completeJson = vi.fn().mockResolvedValue({
       data: brief,
       citations: sources.map(source => ({ url: source.url, title: source.title })),
-      webSearchRequests: 1,
+      webSearchRequests: 0,
     });
     const client = { completeJson } as unknown as OpenRouterClient;
 
     await researchSelectedStory(client, selected, 3, now);
 
     expect(completeJson).toHaveBeenCalledWith(expect.objectContaining({ toolChoice: 'required' }));
+    expect(completeJson).toHaveBeenCalledTimes(1);
   });
 });

--- a/scripts/lib/research.ts
+++ b/scripts/lib/research.ts
@@ -167,7 +167,6 @@ Return each story with: headline, summary, category (one of ${NEWS_CATEGORIES.jo
     );
 
     try {
-      if (response.webSearchRequests < 1) throw new Error('The model did not perform web search');
       return validateNewsCandidates(
         response.data.stories,
         response.citations,
@@ -291,8 +290,6 @@ Return: story, angle, context, at least five keyFacts ({claim, sourceUrls}), tec
     );
 
     try {
-      if (response.webSearchRequests < 1)
-        throw new Error('The model did not perform deeper web search');
       return validateResearchBrief(response.data, story, response.citations, minimumSources);
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

- Accept cited OpenRouter discovery responses even when the optional `usage.server_tool_use.web_search_requests` metric is zero.
- Apply the same behavior to deeper research while retaining the usage counter in diagnostic logs.
- Add regression coverage proving cited discovery and research complete in one request when the metric is unavailable.

## Root cause

The failed workflow returned 24 `url_citation` annotations but reported zero web-search requests in its usage metadata. The pipeline rejected the response based on that unreliable counter even though its existing URL validation confirmed that every accepted story and research source came from web-tool citations.

## Validation

- [x] `pnpm test` — 40 files, 415 tests passed
- [x] `pnpm lint`
- [x] `pnpm build` — 33 pages built
- [x] `pnpm exec prettier --check .`
- [x] Focused strict TypeScript validation for the blog-generation scripts

## Notes

No environment-variable, workflow-schedule, or model changes are required. The usage counter remains visible for diagnostics; URL citations remain mandatory and authoritative.