### PR TITLE
Upgrade Actions and retry empty OpenRouter responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/generate-blog.yml
+++ b/.github/workflows/generate-blog.yml
@@ -13,11 +13,11 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/scripts/__tests__/openrouter.test.ts
+++ b/scripts/__tests__/openrouter.test.ts
@@ -83,4 +83,46 @@ describe('OpenRouterClient', () => {
     expect(body.tool_choice).toBe('required');
     expect(body.tools).toEqual([{ type: 'openrouter:web_search' }]);
   });
+
+  it('retries an empty response once', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: '' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+    });
+
+    expect(result.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after two empty responses', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ choices: [{ message: { content: null } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    await expect(
+      client.completeJson({ systemPrompt: 'System', userPrompt: 'User' })
+    ).rejects.toThrow('OpenRouter returned no content after 2 attempts');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/scripts/lib/openrouter.ts
+++ b/scripts/lib/openrouter.ts
@@ -1,4 +1,5 @@
 const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const MAX_EMPTY_RESPONSE_ATTEMPTS = 2;
 export const DEFAULT_OPENROUTER_MODEL = 'openai/gpt-5.2';
 
 export interface UrlCitation {
@@ -59,51 +60,67 @@ export class OpenRouterClient {
   ) {}
 
   async completeJson<T>(options: CompletionOptions): Promise<CompletionResult<T>> {
-    const response = await this.fetchImpl(OPENROUTER_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
-        'Content-Type': 'application/json',
-        'HTTP-Referer': 'https://www.juanelojga.com',
-        'X-OpenRouter-Title': 'Juan Almeida Blog Research',
-      },
-      body: JSON.stringify({
-        model: this.model,
-        messages: [
-          { role: 'system', content: options.systemPrompt },
-          { role: 'user', content: options.userPrompt },
-        ],
-        response_format: { type: 'json_object' },
-        ...(options.tools?.length ? { tools: options.tools } : {}),
-        ...(options.tools?.length && options.toolChoice ? { tool_choice: options.toolChoice } : {}),
-        temperature: options.temperature ?? 0.3,
-        max_tokens: options.maxTokens ?? 8192,
-      }),
-    });
+    for (let attempt = 1; attempt <= MAX_EMPTY_RESPONSE_ATTEMPTS; attempt += 1) {
+      const response = await this.fetchImpl(OPENROUTER_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+          'HTTP-Referer': 'https://www.juanelojga.com',
+          'X-OpenRouter-Title': 'Juan Almeida Blog Research',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          messages: [
+            { role: 'system', content: options.systemPrompt },
+            { role: 'user', content: options.userPrompt },
+          ],
+          response_format: { type: 'json_object' },
+          ...(options.tools?.length ? { tools: options.tools } : {}),
+          ...(options.tools?.length && options.toolChoice
+            ? { tool_choice: options.toolChoice }
+            : {}),
+          temperature: options.temperature ?? 0.3,
+          max_tokens: options.maxTokens ?? 8192,
+        }),
+      });
 
-    const payload = (await response.json()) as OpenRouterResponse;
-    if (!response.ok) {
-      throw new Error(
-        `OpenRouter request failed (${response.status}): ${payload.error?.message ?? 'unknown error'}`
-      );
+      const payload = (await response.json()) as OpenRouterResponse;
+      if (!response.ok) {
+        throw new Error(
+          `OpenRouter request failed (${response.status}): ${payload.error?.message ?? 'unknown error'}`
+        );
+      }
+
+      const message = payload.choices?.[0]?.message;
+      if (!message?.content) {
+        if (attempt < MAX_EMPTY_RESPONSE_ATTEMPTS) {
+          console.warn(
+            `OpenRouter returned no content (attempt ${attempt}/${MAX_EMPTY_RESPONSE_ATTEMPTS}); retrying`
+          );
+          continue;
+        }
+        throw new Error(
+          `OpenRouter returned no content after ${MAX_EMPTY_RESPONSE_ATTEMPTS} attempts`
+        );
+      }
+
+      const citations = (message.annotations ?? [])
+        .filter(annotation => annotation.type === 'url_citation' && annotation.url_citation?.url)
+        .map(annotation => ({
+          url: annotation.url_citation!.url!,
+          title: annotation.url_citation!.title ?? annotation.url_citation!.url!,
+          content: annotation.url_citation!.content,
+        }));
+
+      return {
+        data: parseJson<T>(message.content),
+        citations,
+        webSearchRequests: payload.usage?.server_tool_use?.web_search_requests ?? 0,
+      };
     }
 
-    const message = payload.choices?.[0]?.message;
-    if (!message?.content) throw new Error('OpenRouter returned no content');
-
-    const citations = (message.annotations ?? [])
-      .filter(annotation => annotation.type === 'url_citation' && annotation.url_citation?.url)
-      .map(annotation => ({
-        url: annotation.url_citation!.url!,
-        title: annotation.url_citation!.title ?? annotation.url_citation!.url!,
-        content: annotation.url_citation!.content,
-      }));
-
-    return {
-      data: parseJson<T>(message.content),
-      citations,
-      webSearchRequests: payload.usage?.server_tool_use?.web_search_requests ?? 0,
-    };
+    throw new Error('OpenRouter completion failed unexpectedly');
   }
 }
 


### PR DESCRIPTION
## Summary

- Upgrade both GitHub workflows to Node 24-native action majors: `actions/checkout@v7`, `actions/setup-node@v7`, and `pnpm/action-setup@v6`.
- Retry an OpenRouter completion once when the provider returns a successful HTTP response without message content.
- Keep retries bounded and return a clear error after two empty responses.
- Add regression coverage for recovery and exhaustion paths.

## Root cause

The failed generation run exposed two independent issues:

1. GitHub warned that the v4 setup actions target deprecated Node 20 and were being forced onto Node 24.
2. The actual failing step received an empty deep-research response from OpenRouter. OpenRouter documents this as a transient provider condition and recommends retrying.

## Validation

- [x] `pnpm test` — 40 files, 417 tests passed
- [x] `pnpm lint`
- [x] `pnpm build` — 33 pages built
- [x] `pnpm exec prettier --check .`
- [x] Focused strict TypeScript validation for the blog-generation scripts

## Notes

No environment variables or schedule settings change. A request is retried only when OpenRouter returns no content; HTTP and validation errors retain their existing behavior.