### PR TITLE
Fix OpenRouter deep research completion

### DIFF
--- a/scripts/__tests__/research.test.ts
+++ b/scripts/__tests__/research.test.ts
@@ -176,7 +176,16 @@ describe('research tool execution', () => {
 
     await researchSelectedStory(client, selected, 3, now);
 
-    expect(completeJson).toHaveBeenCalledWith(expect.objectContaining({ toolChoice: 'required' }));
+    const request = completeJson.mock.calls[0][0];
+    expect(request).not.toHaveProperty('toolChoice');
+    expect(request.tools).toContainEqual({
+      type: 'openrouter:web_fetch',
+      parameters: {
+        engine: 'openrouter',
+        max_uses: 6,
+        max_content_tokens: 12000,
+      },
+    });
     expect(completeJson).toHaveBeenCalledTimes(1);
   });
 });

--- a/scripts/lib/research.ts
+++ b/scripts/lib/research.ts
@@ -276,12 +276,11 @@ Return: story, angle, context, at least five keyFacts ({claim, sourceUrls}), tec
           type: 'openrouter:web_fetch',
           parameters: {
             engine: 'openrouter',
-            max_uses: 10,
-            max_content_tokens: 50000,
+            max_uses: 6,
+            max_content_tokens: 12000,
           },
         },
       ],
-      toolChoice: 'required',
       maxTokens: 8000,
     });
 


### PR DESCRIPTION
## Summary

- allow the OpenRouter deep-research server-tool loop to finish naturally instead of forcing another tool call
- bound web-fetch usage to 6 fetches and 12,000 content tokens per page
- update the research request test to protect the corrected tool configuration

## Root cause

The scheduled blog-generation workflow repeatedly reached deep research, then received successful OpenRouter responses with empty assistant content. Deep research combined `tool_choice: required` with both web search and web fetch, preventing a reliable transition from tool execution to the final JSON response. The fetch allowance could also admit substantially more context than the three-source research brief requires.

## Impact

The generator can synthesize its final research brief after searching and fetching sources while retaining the existing citation and independent-source validation.

## Validation

- `pnpm test -- scripts/__tests__/research.test.ts scripts/__tests__/openrouter.test.ts` — 417 tests passed
- `pnpm lint`
- `pnpm build`
- `git diff --check`

The live OpenRouter path requires the repository's Actions secret and should be verified by manually dispatching the Generate Blog Post workflow after merge.