### PR TITLE
Fix OpenRouter empty responses from reasoning-token exhaustion

### DIFF
--- a/scripts/__tests__/openrouter.test.ts
+++ b/scripts/__tests__/openrouter.test.ts
@@ -84,6 +84,49 @@ describe('OpenRouterClient', () => {
     expect(body.tools).toEqual([{ type: 'openrouter:web_search' }]);
   });
 
+  it('sends the unified reasoning parameter when an effort is set', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: '{"ok":true}' } }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      reasoningEffort: 'low',
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.reasoning).toEqual({ effort: 'low' });
+  });
+
+  it('omits the reasoning parameter by default', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: '{"ok":true}' } }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body).not.toHaveProperty('reasoning');
+  });
+
   it('retries an empty response once', async () => {
     const fetchMock = vi
       .fn()
@@ -110,19 +153,25 @@ describe('OpenRouterClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('stops after two empty responses', async () => {
+  it('stops after three empty responses and reports the finish reason', async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ choices: [{ message: { content: null } }] }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        new Response(
+          JSON.stringify({
+            choices: [{ finish_reason: 'length', message: { content: null } }],
+            usage: {
+              completion_tokens: 5000,
+              completion_tokens_details: { reasoning_tokens: 5000 },
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
     );
     const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
 
     await expect(
       client.completeJson({ systemPrompt: 'System', userPrompt: 'User' })
-    ).rejects.toThrow('OpenRouter returned no content after 2 attempts');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    ).rejects.toThrow(/no content after 3 attempts \(finish_reason=length/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/scripts/__tests__/research.test.ts
+++ b/scripts/__tests__/research.test.ts
@@ -129,7 +129,12 @@ describe('research tool execution', () => {
 
     await discoverWeeklyNews(client, [], options, now);
 
-    expect(completeJson).toHaveBeenCalledWith(expect.objectContaining({ toolChoice: 'required' }));
+    const request = completeJson.mock.calls[0][0];
+    expect(request).not.toHaveProperty('toolChoice');
+    expect(request.reasoningEffort).toBe('low');
+    expect(request.tools).toContainEqual(
+      expect.objectContaining({ type: 'openrouter:web_search' })
+    );
     expect(completeJson).toHaveBeenCalledTimes(1);
   });
 

--- a/scripts/lib/openrouter.ts
+++ b/scripts/lib/openrouter.ts
@@ -1,5 +1,5 @@
 const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
-const MAX_EMPTY_RESPONSE_ATTEMPTS = 2;
+const MAX_EMPTY_RESPONSE_ATTEMPTS = 3;
 export const DEFAULT_OPENROUTER_MODEL = 'openai/gpt-5.2';
 
 export interface UrlCitation {
@@ -20,6 +20,7 @@ interface CompletionOptions {
   toolChoice?: 'auto' | 'required' | 'none';
   temperature?: number;
   maxTokens?: number;
+  reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
 }
 
 export interface CompletionResult<T> {
@@ -30,6 +31,8 @@ export interface CompletionResult<T> {
 
 interface OpenRouterResponse {
   choices?: Array<{
+    finish_reason?: string;
+    native_finish_reason?: string;
     message?: {
       content?: string;
       annotations?: Array<{
@@ -38,7 +41,12 @@ interface OpenRouterResponse {
       }>;
     };
   }>;
-  usage?: { server_tool_use?: { web_search_requests?: number } };
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    completion_tokens_details?: { reasoning_tokens?: number };
+    server_tool_use?: { web_search_requests?: number };
+  };
   error?: { message?: string };
 }
 
@@ -80,6 +88,7 @@ export class OpenRouterClient {
           ...(options.tools?.length && options.toolChoice
             ? { tool_choice: options.toolChoice }
             : {}),
+          ...(options.reasoningEffort ? { reasoning: { effort: options.reasoningEffort } } : {}),
           temperature: options.temperature ?? 0.3,
           max_tokens: options.maxTokens ?? 8192,
         }),
@@ -92,16 +101,20 @@ export class OpenRouterClient {
         );
       }
 
-      const message = payload.choices?.[0]?.message;
+      const choice = payload.choices?.[0];
+      const message = choice?.message;
+      const finishInfo = `finish_reason=${choice?.finish_reason ?? 'unknown'} (native: ${choice?.native_finish_reason ?? 'unknown'}), completion_tokens=${payload.usage?.completion_tokens ?? '?'}, reasoning_tokens=${payload.usage?.completion_tokens_details?.reasoning_tokens ?? '?'}`;
+      console.log(`📡 OpenRouter response: ${finishInfo}`);
+
       if (!message?.content) {
         if (attempt < MAX_EMPTY_RESPONSE_ATTEMPTS) {
           console.warn(
-            `OpenRouter returned no content (attempt ${attempt}/${MAX_EMPTY_RESPONSE_ATTEMPTS}); retrying`
+            `OpenRouter returned no content (attempt ${attempt}/${MAX_EMPTY_RESPONSE_ATTEMPTS}, ${finishInfo}); retrying`
           );
           continue;
         }
         throw new Error(
-          `OpenRouter returned no content after ${MAX_EMPTY_RESPONSE_ATTEMPTS} attempts`
+          `OpenRouter returned no content after ${MAX_EMPTY_RESPONSE_ATTEMPTS} attempts (${finishInfo})`
         );
       }
 

--- a/scripts/lib/post-generator.ts
+++ b/scripts/lib/post-generator.ts
@@ -69,13 +69,15 @@ async function generateWithRetry(
           : ''
       }`,
       temperature: 0.6,
-      maxTokens: 10000,
+      maxTokens: 16000,
+      reasoningEffort: 'low',
     });
 
     try {
       return validateGeneratedPost(response.data, brief, rules);
     } catch (error) {
       validationError = error instanceof Error ? error.message : String(error);
+      console.warn(`⚠️ Generation attempt ${attempt} failed validation: ${validationError}`);
     }
   }
 

--- a/scripts/lib/research.ts
+++ b/scripts/lib/research.ts
@@ -158,8 +158,8 @@ Return each story with: headline, summary, category (one of ${NEWS_CATEGORIES.jo
           },
         },
       ],
-      toolChoice: 'required',
-      maxTokens: 5000,
+      maxTokens: 16000,
+      reasoningEffort: 'low',
     });
 
     console.log(
@@ -176,6 +176,7 @@ Return each story with: headline, summary, category (one of ${NEWS_CATEGORIES.jo
       );
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
+      console.warn(`⚠️ Discovery attempt ${attempt} failed validation: ${lastError}`);
     }
   }
 
@@ -281,7 +282,8 @@ Return: story, angle, context, at least five keyFacts ({claim, sourceUrls}), tec
           },
         },
       ],
-      maxTokens: 8000,
+      maxTokens: 16000,
+      reasoningEffort: 'low',
     });
 
     console.log(
@@ -292,6 +294,7 @@ Return: story, angle, context, at least five keyFacts ({claim, sourceUrls}), tec
       return validateResearchBrief(response.data, story, response.citations, minimumSources);
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
+      console.warn(`⚠️ Research attempt ${attempt} failed validation: ${lastError}`);
     }
   }
 


### PR DESCRIPTION
## Problem

The weekly blog workflow has failed on **every run** since the research-first pipeline landed in #126 (the pre-July-16 successes were the old pipeline). Latest failure: [run 29754445361](https://github.com/juanelojga/juanelojga-webpage/actions/runs/29754445361) — `OpenRouter returned no content after 2 attempts` in `discoverWeeklyNews`.

## Root causes

1. **Reasoning-token exhaustion (primary).** `openai/gpt-5.2` is a reasoning model; its reasoning tokens count against `max_tokens`. Discovery capped at 5,000 and research at 8,000 tokens — after the server-side web-search loop plus reasoning, the budget ran out and the API returned an empty message (`finish_reason: length`). Per the [OpenRouter reasoning docs](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens), `max_tokens` must be strictly higher than the reasoning budget. This is intermittent by nature, matching the flaky history across #127–#130.
2. **Leftover `toolChoice: 'required'` on discovery.** #130 removed it from the research step because it caused this exact symptom, but missed the identical setting in `discoverWeeklyNews`.
3. **No diagnostics.** `finish_reason`/token usage were never logged, and validation errors in retry loops were silently swallowed, making every failure a guessing game.

## Changes

- Remove `toolChoice: 'required'` from discovery (citation validation already proves search ran)
- Raise `max_tokens` to 16k on discovery, research, and both generation calls
- Cap reasoning via OpenRouter's unified `reasoning: { effort: 'low' }` parameter
- Retry empty responses up to 3 times (was 2)
- Log `finish_reason`, `native_finish_reason`, and completion/reasoning token counts on every response; include them in empty-response errors
- Log previously swallowed validation errors before each retry

## Verification

- `pnpm test`: 419 tests pass (updated discovery test, added reasoning-param tests, updated retry test)
- `pnpm lint`: clean
- After merging, trigger the workflow manually (`gh workflow run generate-blog.yml`) to verify end-to-end — if it still fails, the logs will now show the exact finish reason and token usage instead of a bare "no content"

## Fallback

If empty responses persist, set the repo variable `OPENROUTER_MODEL` to a non-reasoning model — the workflow already supports the override, no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)