### PR TITLE
Make OpenRouter JSON parsing resilient and URL validation actionable

### DIFF
--- a/scripts/__tests__/openrouter.test.ts
+++ b/scripts/__tests__/openrouter.test.ts
@@ -127,6 +127,71 @@ describe('OpenRouterClient', () => {
     expect(body).not.toHaveProperty('reasoning');
   });
 
+  it('parses the first JSON object when the model appends trailing text', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: '{"ok":true,"note":"a } inside a string"}\n\nHere is some explanation.',
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+    });
+
+    expect(result.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the first object when the model returns concatenated JSON objects', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: '{"ok":true}\n{"ok":false}' } }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+    });
+
+    expect(result.data.ok).toBe(true);
+  });
+
+  it('retries unparseable content and throws a descriptive error after three attempts', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: 'not json at all' } }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    await expect(
+      client.completeJson({ systemPrompt: 'System', userPrompt: 'User' })
+    ).rejects.toThrow(/unparseable JSON after 3 attempts.*not json at all/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it('retries an empty response once', async () => {
     const fetchMock = vi
       .fn()

--- a/scripts/__tests__/research.test.ts
+++ b/scripts/__tests__/research.test.ts
@@ -115,6 +115,63 @@ describe('validateResearchBrief', () => {
     const citations = sources.map(source => ({ url: source.url, title: source.title }));
     expect(validateResearchBrief(brief, selected, citations, 3)).toEqual(brief);
   });
+
+  it('names the offending source URL instead of throwing a bare Invalid URL error', () => {
+    const selected = story(1);
+    const sources = [
+      {
+        title: 'Primary announcement',
+        url: selected.sourceUrl,
+        publisher: 'Vendor',
+        sourceType: 'primary' as const,
+      },
+      {
+        title: 'Broken source',
+        url: 'not-a-url',
+        publisher: 'Reporter',
+        sourceType: 'reporting' as const,
+      },
+      {
+        title: 'Technical analysis',
+        url: 'https://analysis.example/story',
+        publisher: 'Analyst',
+        sourceType: 'analysis' as const,
+      },
+    ];
+    const brief: ResearchBrief = {
+      story: selected,
+      angle: 'Angle',
+      context: 'Context',
+      keyFacts: Array.from({ length: 5 }, (_, index) => ({
+        claim: `Fact ${index}`,
+        sourceUrls: [selected.sourceUrl],
+      })),
+      technicalImplications: ['Implication'],
+      openQuestions: ['Question'],
+      sources,
+    };
+
+    expect(() => validateResearchBrief(brief, selected, [], 3)).toThrow(
+      'Research sources must use valid HTTPS URLs: not-a-url'
+    );
+  });
+
+  it('rejects a brief whose story has a malformed source URL', () => {
+    const selected = story(1);
+    const brief = {
+      story: { ...selected, sourceUrl: 'nonsense' },
+      angle: 'Angle',
+      context: 'Context',
+      keyFacts: [],
+      technicalImplications: [],
+      openQuestions: [],
+      sources: [],
+    } as unknown as ResearchBrief;
+
+    expect(() => validateResearchBrief(brief, selected, [], 3)).toThrow(
+      'Research brief story is missing a valid HTTPS source URL: nonsense'
+    );
+  });
 });
 
 describe('research tool execution', () => {

--- a/scripts/lib/openrouter.ts
+++ b/scripts/lib/openrouter.ts
@@ -50,13 +50,38 @@ interface OpenRouterResponse {
   error?: { message?: string };
 }
 
+function extractFirstJsonObject(content: string): string | null {
+  const start = content.indexOf('{');
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < content.length; i += 1) {
+    const char = content[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return content.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
 function parseJson<T>(content: string): T {
   try {
     return JSON.parse(content) as T;
   } catch {
-    const match = content.match(/\{[\s\S]*\}/);
-    if (!match) throw new Error('OpenRouter returned invalid JSON');
-    return JSON.parse(match[0]) as T;
+    const candidate = extractFirstJsonObject(content);
+    if (!candidate) throw new Error('OpenRouter returned invalid JSON');
+    return JSON.parse(candidate) as T;
   }
 }
 
@@ -126,8 +151,26 @@ export class OpenRouterClient {
           content: annotation.url_citation!.content,
         }));
 
+      let data: T;
+      try {
+        data = parseJson<T>(message.content);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        const snippet = message.content.slice(0, 200);
+        if (attempt < MAX_EMPTY_RESPONSE_ATTEMPTS) {
+          console.warn(
+            `OpenRouter returned unparseable JSON (attempt ${attempt}/${MAX_EMPTY_RESPONSE_ATTEMPTS}): ${reason}; content starts with: ${snippet}`
+          );
+          continue;
+        }
+        throw new Error(
+          `OpenRouter returned unparseable JSON after ${MAX_EMPTY_RESPONSE_ATTEMPTS} attempts: ${reason}; content starts with: ${snippet}`,
+          { cause: error }
+        );
+      }
+
       return {
-        data: parseJson<T>(message.content),
+        data,
         citations,
         webSearchRequests: payload.usage?.server_tool_use?.web_search_requests ?? 0,
       };

--- a/scripts/lib/research.ts
+++ b/scripts/lib/research.ts
@@ -193,10 +193,12 @@ export function validateResearchBrief(
   citations: UrlCitation[],
   minimumSources: number
 ): ResearchBrief {
-  if (
-    !brief?.story ||
-    normalizeUrl(brief.story.sourceUrl) !== normalizeUrl(selectedStory.sourceUrl)
-  ) {
+  if (!brief?.story || !isHttpsUrl(brief.story.sourceUrl)) {
+    throw new Error(
+      `Research brief story is missing a valid HTTPS source URL: ${brief?.story?.sourceUrl ?? 'none'}`
+    );
+  }
+  if (normalizeUrl(brief.story.sourceUrl) !== normalizeUrl(selectedStory.sourceUrl)) {
     throw new Error('Research brief does not match the selected story');
   }
   if (!brief.angle?.trim() || !brief.context?.trim()) {
@@ -211,6 +213,11 @@ export function validateResearchBrief(
   if (!brief.sources.some(source => source.sourceType === 'primary')) {
     throw new Error('Research brief needs at least one primary source');
   }
+  for (const source of brief.sources) {
+    if (!isHttpsUrl(source.url)) {
+      throw new Error(`Research sources must use valid HTTPS URLs: ${source.url}`);
+    }
+  }
   if (distinctDomains(brief.sources) < minimumSources) {
     throw new Error(`Research brief needs ${minimumSources} independent source domains`);
   }
@@ -218,7 +225,6 @@ export function validateResearchBrief(
   const cited = citationUrls(citations);
   const sourceUrls = new Set<string>();
   for (const source of brief.sources) {
-    if (!isHttpsUrl(source.url)) throw new Error('Research sources must use HTTPS URLs');
     const normalized = normalizeUrl(source.url);
     if (!cited.has(normalized)) {
       throw new Error(`Research source was not returned by web tools: ${source.url}`);


### PR DESCRIPTION
## Problem

[Run 29757333850](https://github.com/juanelojga/juanelojga-webpage/actions/runs/29757333850) (first run after #131) confirms the empty-response bug is fixed — discovery and research now complete with `finish_reason=stop`. The new diagnostics exposed two downstream bugs:

1. **Fatal JSON parse crash.** The research step returned a valid JSON object followed by trailing text. `parseJson` fell back to the greedy regex `\{[\s\S]*\}` (first `{` to last `}`), which was also invalid, and the `SyntaxError` escaped every retry loop — no retry, run dead:
   ```
   ❌ Generation failed: SyntaxError: Unexpected non-whitespace character after JSON at position 513
   ```
2. **Useless retry feedback.** `validateResearchBrief` called `new URL()` on model-returned URLs before validating them, so one malformed URL threw a bare `Invalid URL` — which is also the exact feedback the retry prompt fed back to the model, giving it nothing to correct:
   ```
   ⚠️ Research attempt 1 failed validation: Invalid URL
   ```

## Changes

- `parseJson` now extracts the **first balanced top-level JSON object** with a string-aware brace scanner (handles trailing prose, concatenated objects, code fences)
- Unparseable content is retried inside `completeJson` like empty responses (up to 3 attempts), logging a content snippet; the final error names the parse failure and snippet
- `validateResearchBrief` validates the story URL and every source URL (`isHttpsUrl`) **before** any raw `new URL()` call, and every error names the offending URL so the model's retry can actually fix it

## Verification

- `pnpm test`: 424 tests pass (5 new: trailing-text parsing, concatenated objects, unparseable retry, malformed source URL message, malformed story URL message)
- `pnpm lint`: clean
- After merge: `gh workflow run generate-blog.yml` — the #131 diagnostics plus these fixes should either complete the pipeline or say precisely what's wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)