### PR TITLE
Inject the selected story into the research brief server-side

### DIFF
--- a/scripts/__tests__/research.test.ts
+++ b/scripts/__tests__/research.test.ts
@@ -217,8 +217,7 @@ describe('research tool execution', () => {
         sourceType: 'analysis' as const,
       },
     ];
-    const brief: ResearchBrief = {
-      story: selected,
+    const briefWithoutStory = {
       angle: 'A grounded engineering angle',
       context: 'Verified context',
       keyFacts: Array.from({ length: 5 }, (_, index) => ({
@@ -230,15 +229,17 @@ describe('research tool execution', () => {
       sources,
     };
     const completeJson = vi.fn().mockResolvedValue({
-      data: brief,
+      data: briefWithoutStory,
       citations: sources.map(source => ({ url: source.url, title: source.title })),
       webSearchRequests: 0,
     });
     const client = { completeJson } as unknown as OpenRouterClient;
 
-    await researchSelectedStory(client, selected, 3, now);
+    const brief = await researchSelectedStory(client, selected, 3, now);
 
+    expect(brief.story).toEqual(selected);
     const request = completeJson.mock.calls[0][0];
+    expect(request.userPrompt).not.toMatch(/Return: story/);
     expect(request).not.toHaveProperty('toolChoice');
     expect(request.tools).toContainEqual({
       type: 'openrouter:web_fetch',

--- a/scripts/lib/research.ts
+++ b/scripts/lib/research.ts
@@ -23,6 +23,8 @@ interface ResearchOptions {
   subjects: string[];
 }
 
+const MAX_VALIDATION_ATTEMPTS = 3;
+
 function isHttpsUrl(value: string): boolean {
   try {
     return new URL(value).protocol === 'https:';
@@ -130,7 +132,7 @@ export async function discoverWeeklyNews(
 ): Promise<NewsCandidate[]> {
   let lastError = '';
 
-  for (let attempt = 1; attempt <= 2; attempt += 1) {
+  for (let attempt = 1; attempt <= MAX_VALIDATION_ATTEMPTS; attempt += 1) {
     const response = await client.completeJson<DiscoveryResponse>({
       systemPrompt: `You are a meticulous technology news editor. You must use web search before answering.
 Find distinct, consequential news—not evergreen tutorials, rumors, opinion-only posts, or minor product marketing.
@@ -180,7 +182,9 @@ Return each story with: headline, summary, category (one of ${NEWS_CATEGORIES.jo
     }
   }
 
-  throw new Error(`Could not discover valid weekly news after two attempts: ${lastError}`);
+  throw new Error(
+    `Could not discover valid weekly news after ${MAX_VALIDATION_ATTEMPTS} attempts: ${lastError}`
+  );
 }
 
 function distinctDomains(sources: ResearchSource[]): number {
@@ -254,7 +258,7 @@ export async function researchSelectedStory(
 ): Promise<ResearchBrief> {
   let lastError = '';
 
-  for (let attempt = 1; attempt <= 2; attempt += 1) {
+  for (let attempt = 1; attempt <= MAX_VALIDATION_ATTEMPTS; attempt += 1) {
     const response = await client.completeJson<ResearchBrief>({
       systemPrompt: `You are a technical research analyst. Use web search and web fetch extensively before answering.
 Verify claims against the fetched pages. Separate facts from interpretation. Prefer primary material and corroborate it with independent reporting or analysis.
@@ -268,7 +272,7 @@ Use at least ${minimumSources} sources from different domains, including at leas
 Do not use social posts, search-result pages, scraped copies, or sources you did not actually read.
 ${lastError ? `The previous result failed validation: ${lastError}\nCorrect every issue.` : ''}
 
-Return: story, angle, context, at least five keyFacts ({claim, sourceUrls}), technicalImplications, openQuestions, and sources ({title, url, publisher, publishedAt when known, sourceType as primary/reporting/analysis}).`,
+Return: angle, context, at least five keyFacts ({claim, sourceUrls}), technicalImplications, openQuestions, and sources ({title, url, publisher, publishedAt when known, sourceType as primary/reporting/analysis}).`,
       tools: [
         {
           type: 'openrouter:web_search',
@@ -297,14 +301,21 @@ Return: story, angle, context, at least five keyFacts ({claim, sourceUrls}), tec
     );
 
     try {
-      return validateResearchBrief(response.data, story, response.citations, minimumSources);
+      return validateResearchBrief(
+        { ...response.data, story },
+        story,
+        response.citations,
+        minimumSources
+      );
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
       console.warn(`⚠️ Research attempt ${attempt} failed validation: ${lastError}`);
     }
   }
 
-  throw new Error(`Could not build a valid research brief after two attempts: ${lastError}`);
+  throw new Error(
+    `Could not build a valid research brief after ${MAX_VALIDATION_ATTEMPTS} attempts: ${lastError}`
+  );
 }
 
 export function categoryForStory(category: NewsCandidate['category']): string {


### PR DESCRIPTION
## Problem

[Run 29760615425](https://github.com/juanelojga/juanelojga-webpage/actions/runs/29760615425) (after #132) got through discovery cleanly, then failed both research attempts with:

```
⚠️ Research attempt 1 failed validation: Research brief story is missing a valid HTTPS source URL: none
```

The research prompt asked gpt-5.2 to `Return: story, angle, context, …` without ever specifying the shape of `story`, and validation then required `brief.story.sourceUrl` to match the selected story. The model returned `story` in some other shape (or not at all) — twice. Requiring the model to echo back data the caller already holds is pure fragility: it adds a failure point and zero information.

## Changes

- Remove `story` from the requested model output; inject the locally-known selected story into the brief before validation (`{ ...response.data, story }`)
- Raise the validation retry loops in `discoverWeeklyNews` and `researchSelectedStory` from 2 → 3 attempts (`MAX_VALIDATION_ATTEMPTS`) — attempt exhaustion has been the recurring kill switch across every failed run, and one extra call is cheap next to a dead weekly run

## Verification

- `pnpm test`: 424 tests pass — the deep-research test now feeds a brief *without* a `story` field and asserts the selected story is injected, and that the prompt no longer requests `story`
- `pnpm lint`: clean
- After merge: `gh workflow run generate-blog.yml`. Remaining pipeline steps (EN/ES post generation) already have descriptive validation with retry feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)