### PR TITLE
Rearchitect blog generation to repair-then-validate

### DIFF
--- a/.github/workflows/generate-blog.yml
+++ b/.github/workflows/generate-blog.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -28,7 +29,7 @@ jobs:
         run: pnpm generate:blog
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'openai/gpt-5.2' }}
+          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'deepseek/deepseek-v3.2' }}
 
       - name: Create branch and PR
         env:

--- a/scripts/__tests__/openrouter.test.ts
+++ b/scripts/__tests__/openrouter.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe('createOpenRouterClient', () => {
-  it('uses openai/gpt-5.2 by default', () => {
+  it('uses deepseek/deepseek-v3.2 by default', () => {
     vi.stubEnv('OPENROUTER_API_KEY', 'test-key');
     vi.stubEnv('OPENROUTER_MODEL', '');
     expect(createOpenRouterClient().model).toBe(DEFAULT_OPENROUTER_MODEL);
@@ -216,6 +216,361 @@ describe('OpenRouterClient', () => {
 
     expect(result.data.ok).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends a strict json_schema response format when a schema is supplied', async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      schema: { name: 'test_schema', schema: { type: 'object' } },
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.response_format).toEqual({
+      type: 'json_schema',
+      json_schema: { name: 'test_schema', strict: true, schema: { type: 'object' } },
+    });
+  });
+
+  it('keeps json_object as the response format without a schema', async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    await client.completeJson<{ ok: boolean }>({ systemPrompt: 'System', userPrompt: 'User' });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('falls back to json_object when the provider rejects the schema', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { message: 'response_format json_schema is not supported' } }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      schema: { name: 'test_schema', schema: { type: 'object' } },
+    });
+
+    expect(result.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+    expect(secondBody.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('retries schema mode without the schema when tool citations are missing', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: '{"ok":true}',
+                  annotations: [
+                    {
+                      type: 'url_citation',
+                      url_citation: { url: 'https://example.com/news', title: 'News' },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      tools: [{ type: 'openrouter:web_search' }],
+      schema: { name: 'test_schema', schema: { type: 'object' } },
+    });
+
+    expect(result.citations).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+    expect(secondBody.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('drops the schema first when tool-call markup appears under json_schema', async () => {
+    const markupContent = '<function_calls>\n<invoke name="openrouter_web_search">\n</invoke>';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: markupContent } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      tools: [{ type: 'openrouter:web_search' }],
+      schema: { name: 'test_schema', schema: { type: 'object' } },
+    });
+
+    expect(result.data.ok).toBe(true);
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+    // Schema dropped but server tools kept — they work without the schema.
+    expect(secondBody.response_format).toEqual({ type: 'json_object' });
+    expect(secondBody.tools).toEqual([{ type: 'openrouter:web_search' }]);
+    expect(secondBody).not.toHaveProperty('plugins');
+  });
+
+  it('switches to the web plugin when the provider returns an unexecuted tool call', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                finish_reason: 'tool_calls',
+                message: { content: null, tool_calls: [{ id: 'call_1' }] },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: '{"ok":true}',
+                  annotations: [
+                    {
+                      type: 'url_citation',
+                      url_citation: { url: 'https://example.com/news', title: 'News' },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      tools: [{ type: 'openrouter:web_search', parameters: { engine: 'exa', max_results: 8 } }],
+    });
+
+    expect(result.data.ok).toBe(true);
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+    expect(secondBody.plugins).toEqual([{ id: 'web', engine: 'exa', max_results: 8 }]);
+    expect(secondBody).not.toHaveProperty('tools');
+  });
+
+  it('falls back to the web plugin when the model emits tool-call markup as text', async () => {
+    const markupContent =
+      '<function_calls>\n<invoke name="openrouter_web_search">\n<parameter name="query">news</parameter>\n</invoke>\n</function_calls>';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: markupContent } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: '{"ok":true}',
+                  annotations: [
+                    {
+                      type: 'url_citation',
+                      url_citation: { url: 'https://example.com/news', title: 'News' },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      tools: [
+        { type: 'openrouter:web_search', parameters: { engine: 'exa', max_results: 8 } },
+        { type: 'openrouter:web_fetch' },
+      ],
+    });
+
+    expect(result.data.ok).toBe(true);
+    expect(result.citations).toHaveLength(1);
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+    expect(secondBody.plugins).toEqual([{ id: 'web', engine: 'exa', max_results: 8 }]);
+    expect(secondBody).not.toHaveProperty('tools');
+  });
+
+  it('remembers that server-side tools are unsupported across calls', async () => {
+    const markupContent = '<tool_call>{"name":"openrouter_web_search"}</tool_call>';
+    const goodResponse = () =>
+      new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: '{"ok":true}',
+                annotations: [
+                  {
+                    type: 'url_citation',
+                    url_citation: { url: 'https://example.com/news', title: 'News' },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: markupContent } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValue(goodResponse());
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+    const request = {
+      systemPrompt: 'System',
+      userPrompt: 'User',
+      tools: [{ type: 'openrouter:web_search' as const }],
+    };
+
+    await client.completeJson<{ ok: boolean }>(request);
+    fetchMock.mockResolvedValue(goodResponse());
+    await client.completeJson<{ ok: boolean }>(request);
+
+    // The second completeJson call starts directly in plugin mode.
+    const thirdBody = JSON.parse(String(fetchMock.mock.calls[2][1]?.body));
+    expect(thirdBody.plugins).toEqual([{ id: 'web', engine: 'exa', max_results: 8 }]);
+    expect(thirdBody).not.toHaveProperty('tools');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries transient HTTP errors with backoff', async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'rate limited' } }), {
+          status: 429,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch, sleep);
+
+    const result = await client.completeJson<{ ok: boolean }>({
+      systemPrompt: 'System',
+      userPrompt: 'User',
+    });
+
+    expect(result.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(5000);
+  });
+
+  it('gives up on persistent server errors after three retries', async () => {
+    const sleep = vi.fn(async () => {});
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: 'upstream down' } }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch, sleep);
+
+    await expect(
+      client.completeJson({ systemPrompt: 'System', userPrompt: 'User' })
+    ).rejects.toThrow('OpenRouter request failed (502): upstream down');
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry authentication errors', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: 'invalid key' } }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    const client = new OpenRouterClient('key', 'model', fetchMock as typeof fetch);
+
+    await expect(
+      client.completeJson({ systemPrompt: 'System', userPrompt: 'User' })
+    ).rejects.toThrow('OpenRouter request failed (401): invalid key');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('stops after three empty responses and reports the finish reason', async () => {

--- a/scripts/__tests__/post-generator.test.ts
+++ b/scripts/__tests__/post-generator.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { OpenRouterClient } from '../lib/openrouter';
+import { generateEnglishPost, generateSpanishPost } from '../lib/post-generator';
+import type { GeneratedPost, ResearchBrief } from '../lib/types';
+
+const rules = {
+  wordsMin: 1200,
+  wordsMax: 2000,
+  tone: 'practical',
+  persona: 'Juan Almeida, a full-stack & AI engineer',
+  avoid: ['generic advice'],
+};
+
+const sources = [
+  {
+    title: 'Primary announcement',
+    url: 'https://vendor.example/announcement',
+    publisher: 'Vendor',
+    sourceType: 'primary' as const,
+  },
+  {
+    title: 'Independent report',
+    url: 'https://report.example/story',
+    publisher: 'Reporter',
+    sourceType: 'reporting' as const,
+  },
+  {
+    title: 'Technical analysis',
+    url: 'https://analysis.example/story',
+    publisher: 'Analyst',
+    sourceType: 'analysis' as const,
+  },
+];
+
+const brief: ResearchBrief = {
+  story: {
+    headline: 'News story',
+    summary: 'Summary',
+    category: 'software-development',
+    publishedAt: '2026-07-17',
+    sourceUrl: sources[0].url,
+    sourceName: 'Vendor',
+    whyItMatters: 'Impact',
+  },
+  angle: 'Angle',
+  context: 'Context',
+  keyFacts: Array.from({ length: 5 }, (_, index) => ({
+    claim: `Fact ${index}`,
+    sourceUrls: [sources[index % sources.length].url],
+  })),
+  technicalImplications: ['Implication'],
+  openQuestions: ['Question'],
+  sources,
+};
+
+function validPost(content: string): GeneratedPost {
+  return {
+    title: 'A valid generated title',
+    content,
+    tags: ['ai', 'tooling', 'engineering'],
+    summary: 'S'.repeat(130),
+    faq: [
+      { question: 'Q1?', answer: 'A1' },
+      { question: 'Q2?', answer: 'A2' },
+      { question: 'Q3?', answer: 'A3' },
+    ],
+  };
+}
+
+function longContent(citations: string[]): string {
+  const links = citations.map((url, index) => `[Source ${index + 1}](${url})`).join(' and ');
+  return `${'lorem ipsum '.repeat(650)}${links}`;
+}
+
+function clientReturning(...posts: GeneratedPost[]): {
+  client: OpenRouterClient;
+  completeJson: ReturnType<typeof vi.fn>;
+} {
+  const completeJson = vi.fn();
+  for (const post of posts) {
+    completeJson.mockResolvedValueOnce({ data: post, citations: [], webSearchRequests: 0 });
+  }
+  completeJson.mockResolvedValue({
+    data: posts[posts.length - 1],
+    citations: [],
+    webSearchRequests: 0,
+  });
+  return { client: { completeJson } as unknown as OpenRouterClient, completeJson };
+}
+
+describe('generateEnglishPost', () => {
+  it('accepts citations that differ from sources only by normalization', async () => {
+    const content = longContent([`${sources[0].url}/`, `${sources[1].url}?utm_source=x`]);
+    const { client, completeJson } = clientReturning(validPost(content));
+
+    const post = await generateEnglishPost(client, brief, 'programming', rules);
+
+    expect(post.content).toBe(content);
+    expect(completeJson).toHaveBeenCalledTimes(1);
+    expect(completeJson.mock.calls[0][0].schema).toMatchObject({ name: 'generated_post' });
+  });
+
+  it('rejects posts citing unresearched URLs after all attempts', async () => {
+    const content = longContent([sources[0].url, 'https://unknown.example/made-up']);
+    const { client, completeJson } = clientReturning(validPost(content));
+
+    await expect(generateEnglishPost(client, brief, 'programming', rules)).rejects.toThrow(
+      'Generated post cites an unresearched URL: https://unknown.example/made-up'
+    );
+    expect(completeJson).toHaveBeenCalledTimes(3);
+  });
+
+  it('feeds the failed post back into the retry prompt for repair', async () => {
+    const badPost = {
+      ...validPost(longContent([sources[0].url, sources[1].url])),
+      summary: 'Too short',
+    };
+    const goodPost = validPost(longContent([sources[0].url, sources[1].url]));
+    const { client, completeJson } = clientReturning(badPost, goodPost);
+
+    const post = await generateEnglishPost(client, brief, 'programming', rules);
+
+    expect(post.summary).toBe(goodPost.summary);
+    expect(completeJson).toHaveBeenCalledTimes(2);
+    const retryPrompt = completeJson.mock.calls[1][0].userPrompt;
+    expect(retryPrompt).toContain('Your previous attempt produced this post JSON');
+    expect(retryPrompt).toContain(
+      'It failed validation: Generated summary must be 120–160 characters'
+    );
+  });
+
+  it('prompts a word ceiling below the hard validation cap', async () => {
+    const content = longContent([sources[0].url, sources[1].url]);
+    const { client, completeJson } = clientReturning(validPost(content));
+
+    await generateEnglishPost(client, brief, 'programming', rules);
+
+    const systemPrompt = completeJson.mock.calls[0][0].systemPrompt;
+    expect(systemPrompt).toContain('between 1200 and 1800 words');
+    expect(systemPrompt).not.toContain('and 2000 words');
+  });
+
+  it('tells the model exactly how many words to cut when a post runs long', async () => {
+    const overlongPost = validPost(
+      `${'lorem ipsum '.repeat(1050)}${longContent([sources[0].url, sources[1].url])}`
+    );
+    const goodPost = validPost(longContent([sources[0].url, sources[1].url]));
+    const { client, completeJson } = clientReturning(overlongPost, goodPost);
+
+    const post = await generateEnglishPost(client, brief, 'programming', rules);
+
+    expect(post).toEqual(goodPost);
+    const retryPrompt = completeJson.mock.calls[1][0].userPrompt;
+    expect(retryPrompt).toMatch(/remove at least \d+ words/);
+  });
+
+  it('reports every validation problem at once so one retry can fix them all', async () => {
+    const badPost = {
+      ...validPost(
+        `${'lorem ipsum '.repeat(1050)}${longContent([sources[0].url, sources[1].url])}`
+      ),
+      summary: 'Too short',
+    };
+    const goodPost = validPost(longContent([sources[0].url, sources[1].url]));
+    const { client, completeJson } = clientReturning(badPost, goodPost);
+
+    await generateEnglishPost(client, brief, 'programming', rules);
+
+    const retryPrompt = completeJson.mock.calls[1][0].userPrompt;
+    expect(retryPrompt).toContain('Generated summary must be 120–160 characters');
+    expect(retryPrompt).toMatch(/remove at least \d+ words/);
+  });
+
+  it('caps the Spanish target at the English post word count', async () => {
+    const englishPost = validPost(longContent([sources[0].url, sources[1].url]));
+    const englishWords = englishPost.content.trim().split(/\s+/).filter(Boolean).length;
+    const { client, completeJson } = clientReturning(englishPost);
+
+    await generateSpanishPost(client, englishPost, brief, rules);
+
+    const systemPrompt = completeJson.mock.calls[0][0].systemPrompt;
+    expect(systemPrompt).toContain(`between 1200 and ${englishWords} words`);
+    expect(systemPrompt).toContain(`The English post is ${englishWords} words`);
+    expect(systemPrompt).toContain('must not be longer than the English post');
+  });
+
+  it('repairs malformed shapes before validating', async () => {
+    const content = longContent([sources[0].url, sources[1].url]);
+    const malformed = {
+      title: ['A title', 'in an array'],
+      content,
+      tags: ['AI', 'Tooling', 'Engineering'],
+      summary: 'S'.repeat(130),
+      faq: [
+        { question: 'Q1?', answer: 'A1' },
+        { question: '', answer: 'dropped' },
+        { question: 'Q2?', answer: 'A2' },
+        { question: 'Q3?', answer: 'A3' },
+      ],
+    } as unknown as GeneratedPost;
+    const { client } = clientReturning(malformed);
+
+    const post = await generateEnglishPost(client, brief, 'programming', rules);
+
+    expect(post.title).toBe('A title\n\nin an array');
+    expect(post.tags).toEqual(['ai', 'tooling', 'engineering']);
+    expect(post.faq).toHaveLength(3);
+  });
+});

--- a/scripts/__tests__/repair.test.ts
+++ b/scripts/__tests__/repair.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest';
+import {
+  coerceSourceType,
+  coerceString,
+  coerceStringArray,
+  repairNewsCandidates,
+  repairResearchBrief,
+} from '../lib/repair';
+import { validateResearchBrief } from '../lib/research';
+import type { NewsCandidate } from '../lib/types';
+
+const now = new Date('2026-07-18T12:00:00.000Z');
+const options = {
+  lookbackDays: 7,
+  candidateCount: 4,
+  minimumSources: 3,
+  subjects: ['software development', 'ai', 'coding', 'software architecture'],
+};
+
+function story(index: number, overrides: Partial<NewsCandidate> = {}): NewsCandidate {
+  return {
+    headline: `News story ${index}`,
+    summary: `Verified summary ${index}`,
+    category: 'software-development',
+    publishedAt: '2026-07-17',
+    sourceUrl: `https://source${index}.example/news`,
+    sourceName: `Source ${index}`,
+    whyItMatters: `Technical impact ${index}`,
+    ...overrides,
+  };
+}
+
+function citationsFor(stories: NewsCandidate[]) {
+  return stories.map(item => ({ url: item.sourceUrl, title: item.headline }));
+}
+
+describe('coerceString', () => {
+  it('trims plain strings', () => {
+    expect(coerceString('  hello  ')).toBe('hello');
+  });
+
+  it('joins arrays of strings', () => {
+    expect(coerceString(['first part', '', 'second part'])).toBe('first part\n\nsecond part');
+  });
+
+  it('joins the values of plain objects', () => {
+    expect(coerceString({ background: 'why it happened', whyNow: 'timing' })).toBe(
+      'why it happened\n\ntiming'
+    );
+  });
+
+  it('stringifies numbers and booleans', () => {
+    expect(coerceString(42)).toBe('42');
+    expect(coerceString(true)).toBe('true');
+  });
+
+  it('returns an empty string for null and undefined', () => {
+    expect(coerceString(null)).toBe('');
+    expect(coerceString(undefined)).toBe('');
+  });
+});
+
+describe('coerceStringArray', () => {
+  it('wraps a single string', () => {
+    expect(coerceStringArray('one item')).toEqual(['one item']);
+  });
+
+  it('coerces array elements and drops empties', () => {
+    expect(coerceStringArray(['a', '', null, 3])).toEqual(['a', '3']);
+  });
+
+  it('returns an empty array for non-array, non-string input', () => {
+    expect(coerceStringArray(undefined)).toEqual([]);
+    expect(coerceStringArray({})).toEqual([]);
+  });
+});
+
+describe('coerceSourceType', () => {
+  it('normalizes case and whitespace', () => {
+    expect(coerceSourceType(' PRIMARY ')).toBe('primary');
+  });
+
+  it('maps synonyms', () => {
+    expect(coerceSourceType('official')).toBe('primary');
+    expect(coerceSourceType('news')).toBe('reporting');
+    expect(coerceSourceType('opinion')).toBe('analysis');
+  });
+
+  it('never defaults to primary', () => {
+    expect(coerceSourceType('garbage')).toBe('reporting');
+    expect(coerceSourceType(undefined)).toBe('reporting');
+    expect(coerceSourceType(42)).toBe('reporting');
+  });
+});
+
+describe('repairNewsCandidates', () => {
+  it('keeps a fully valid batch', () => {
+    const stories = [story(1), story(2), story(3), story(4)];
+    const { valid, rejected } = repairNewsCandidates(
+      stories,
+      citationsFor(stories),
+      [],
+      now,
+      options
+    );
+    expect(valid).toEqual(stories);
+    expect(rejected).toEqual([]);
+  });
+
+  it('drops stale stories but keeps the rest', () => {
+    const stories = [story(1, { publishedAt: '2026-07-01' }), story(2), story(3), story(4)];
+    const { valid, rejected } = repairNewsCandidates(
+      stories,
+      citationsFor(stories),
+      [],
+      now,
+      options
+    );
+    expect(valid).toEqual(stories.slice(1));
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0].reason).toContain('outside the 7-day window');
+  });
+
+  it('drops sources not returned by web research', () => {
+    const stories = [story(1), story(2), story(3), story(4)];
+    const { valid, rejected } = repairNewsCandidates(
+      stories,
+      citationsFor(stories.slice(1)),
+      [],
+      now,
+      options
+    );
+    expect(valid).toEqual(stories.slice(1));
+    expect(rejected[0].reason).toContain('was not returned by web research');
+  });
+
+  it('drops stories already recorded in history', () => {
+    const stories = [story(1), story(2), story(3), story(4)];
+    const history = [{ topic: 'Older article', sourceUrls: [stories[0].sourceUrl] }];
+    const { valid, rejected } = repairNewsCandidates(
+      stories,
+      citationsFor(stories),
+      history,
+      now,
+      options
+    );
+    expect(valid).toEqual(stories.slice(1));
+    expect(rejected[0].reason).toContain('already covered');
+  });
+
+  it('coerces category case before validating it', () => {
+    const stories = [story(1, { category: 'AI' as NewsCandidate['category'] })];
+    const { valid } = repairNewsCandidates(stories, citationsFor(stories), [], now, options);
+    expect(valid[0].category).toBe('ai');
+  });
+
+  it('handles non-array input', () => {
+    const { valid, rejected } = repairNewsCandidates(undefined, [], [], now, options);
+    expect(valid).toEqual([]);
+    expect(rejected).toEqual([]);
+  });
+});
+
+describe('repairResearchBrief', () => {
+  const selected = story(1);
+  const sources = [
+    {
+      title: 'Primary announcement',
+      url: selected.sourceUrl,
+      publisher: 'Vendor',
+      sourceType: 'primary',
+    },
+    {
+      title: 'Independent report',
+      url: 'https://report.example/story',
+      publisher: 'Reporter',
+      sourceType: 'reporting',
+    },
+    {
+      title: 'Technical analysis',
+      url: 'https://analysis.example/story',
+      publisher: 'Analyst',
+      sourceType: 'analysis',
+    },
+  ];
+  const citations = sources.map(source => ({ url: source.url, title: source.title }));
+
+  function rawBrief(overrides: Record<string, unknown> = {}) {
+    return {
+      angle: 'What working engineers should understand',
+      context: 'The technical and historical context.',
+      keyFacts: Array.from({ length: 5 }, (_, index) => ({
+        claim: `Verified fact ${index}`,
+        sourceUrls: [sources[index % sources.length].url],
+      })),
+      technicalImplications: ['One implication'],
+      openQuestions: ['One open question'],
+      sources,
+      ...overrides,
+    };
+  }
+
+  it('forces the selected story into the brief', () => {
+    const { brief } = repairResearchBrief(rawBrief({ story: story(9) }), selected, citations);
+    expect(brief.story).toEqual(selected);
+  });
+
+  it('filters uncited sources and rewires facts to survivors', () => {
+    const uncited = {
+      title: 'Unfetched spec',
+      url: 'https://raw.example.com/spec.md',
+      publisher: 'Repo',
+      sourceType: 'primary',
+    };
+    const raw = rawBrief({
+      sources: [...sources, uncited],
+      keyFacts: [
+        { claim: 'Cited fact', sourceUrls: [sources[0].url, uncited.url] },
+        { claim: 'Orphaned fact', sourceUrls: [uncited.url] },
+        ...Array.from({ length: 4 }, (_, index) => ({
+          claim: `Fact ${index}`,
+          sourceUrls: [sources[index % sources.length].url],
+        })),
+      ],
+    });
+
+    const { brief, dropped } = repairResearchBrief(raw, selected, citations);
+
+    expect(brief.sources).toHaveLength(3);
+    expect(brief.sources.map(source => source.url)).not.toContain(uncited.url);
+    expect(brief.keyFacts[0].sourceUrls).toEqual([sources[0].url]);
+    expect(brief.keyFacts.map(fact => fact.claim)).not.toContain('Orphaned fact');
+    expect(dropped.join('\n')).toContain('uncited source');
+    expect(dropped.join('\n')).toContain('Orphaned fact');
+  });
+
+  it('coerces an array-valued context so the brief passes strict validation', () => {
+    const raw = rawBrief({ context: ['First paragraph.', 'Second paragraph.'] });
+    const { brief } = repairResearchBrief(raw, selected, citations);
+    expect(brief.context).toBe('First paragraph.\n\nSecond paragraph.');
+    expect(validateResearchBrief(brief, selected, citations, 3)).toEqual(brief);
+  });
+
+  it('still fails validation when filtering leaves too few sources', () => {
+    const raw = rawBrief();
+    const partialCitations = citations.slice(0, 1);
+    const { brief } = repairResearchBrief(raw, selected, partialCitations);
+    expect(brief.sources).toHaveLength(1);
+    expect(() => validateResearchBrief(brief, selected, partialCitations, 3)).toThrow(
+      'needs at least five sourced facts'
+    );
+  });
+
+  it('never fabricates a primary source type', () => {
+    const raw = rawBrief({
+      sources: sources.map(source => ({ ...source, sourceType: 'mystery' })),
+    });
+    const { brief } = repairResearchBrief(raw, selected, citations);
+    expect(brief.sources.every(source => source.sourceType === 'reporting')).toBe(true);
+    expect(() => validateResearchBrief(brief, selected, citations, 3)).toThrow(
+      'needs at least one primary source'
+    );
+  });
+
+  it('handles a completely malformed payload without throwing', () => {
+    const { brief } = repairResearchBrief('not an object', selected, citations);
+    expect(brief.story).toEqual(selected);
+    expect(brief.sources).toEqual([]);
+    expect(brief.keyFacts).toEqual([]);
+  });
+});

--- a/scripts/__tests__/research.test.ts
+++ b/scripts/__tests__/research.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import type { OpenRouterClient } from '../lib/openrouter';
 import {
   discoverWeeklyNews,
+  researchAnyStory,
   researchSelectedStory,
   selectRandomStory,
-  validateNewsCandidates,
   validateResearchBrief,
 } from '../lib/research';
 import type { NewsCandidate, ResearchBrief } from '../lib/types';
@@ -34,36 +34,42 @@ function citationsFor(stories: NewsCandidate[]) {
   return stories.map(item => ({ url: item.sourceUrl, title: item.headline }));
 }
 
-describe('validateNewsCandidates', () => {
-  it('accepts exactly four fresh, distinct, cited stories', () => {
-    const stories = [story(1), story(2), story(3), story(4)];
-    expect(validateNewsCandidates(stories, citationsFor(stories), [], now, options)).toEqual(
-      stories
-    );
-  });
+function sourcesFor(selected: NewsCandidate) {
+  return [
+    {
+      title: 'Primary announcement',
+      url: selected.sourceUrl,
+      publisher: 'Vendor',
+      sourceType: 'primary' as const,
+    },
+    {
+      title: 'Independent report',
+      url: 'https://report.example/story',
+      publisher: 'Reporter',
+      sourceType: 'reporting' as const,
+    },
+    {
+      title: 'Technical analysis',
+      url: 'https://analysis.example/story',
+      publisher: 'Analyst',
+      sourceType: 'analysis' as const,
+    },
+  ];
+}
 
-  it('rejects stale stories', () => {
-    const stories = [story(1, { publishedAt: '2026-07-01' }), story(2), story(3), story(4)];
-    expect(() => validateNewsCandidates(stories, citationsFor(stories), [], now, options)).toThrow(
-      'outside the 7-day window'
-    );
-  });
-
-  it('rejects sources not returned by web research', () => {
-    const stories = [story(1), story(2), story(3), story(4)];
-    expect(() =>
-      validateNewsCandidates(stories, citationsFor(stories.slice(1)), [], now, options)
-    ).toThrow('was not returned by web research');
-  });
-
-  it('rejects a source URL already recorded in history', () => {
-    const stories = [story(1), story(2), story(3), story(4)];
-    const history = [{ topic: 'Older article', sourceUrls: [stories[0].sourceUrl] }];
-    expect(() =>
-      validateNewsCandidates(stories, citationsFor(stories), history, now, options)
-    ).toThrow('already covered');
-  });
-});
+function briefWithoutStory(sources: ReturnType<typeof sourcesFor>) {
+  return {
+    angle: 'A grounded engineering angle',
+    context: 'Verified context',
+    keyFacts: Array.from({ length: 5 }, (_, index) => ({
+      claim: `Fact ${index}`,
+      sourceUrls: [sources[index % sources.length].url],
+    })),
+    technicalImplications: ['Implication'],
+    openQuestions: ['Question'],
+    sources,
+  };
+}
 
 describe('selectRandomStory', () => {
   it('uses the supplied random index', () => {
@@ -79,38 +85,8 @@ describe('selectRandomStory', () => {
 describe('validateResearchBrief', () => {
   it('requires primary and independent cited sources', () => {
     const selected = story(1);
-    const sources = [
-      {
-        title: 'Primary announcement',
-        url: selected.sourceUrl,
-        publisher: 'Vendor',
-        sourceType: 'primary' as const,
-      },
-      {
-        title: 'Independent report',
-        url: 'https://report.example/story',
-        publisher: 'Reporter',
-        sourceType: 'reporting' as const,
-      },
-      {
-        title: 'Technical analysis',
-        url: 'https://analysis.example/story',
-        publisher: 'Analyst',
-        sourceType: 'analysis' as const,
-      },
-    ];
-    const brief: ResearchBrief = {
-      story: selected,
-      angle: 'What working engineers should understand',
-      context: 'The technical and historical context.',
-      keyFacts: Array.from({ length: 5 }, (_, index) => ({
-        claim: `Verified fact ${index}`,
-        sourceUrls: [sources[index % sources.length].url],
-      })),
-      technicalImplications: ['One implication'],
-      openQuestions: ['One open question'],
-      sources,
-    };
+    const sources = sourcesFor(selected);
+    const brief: ResearchBrief = { story: selected, ...briefWithoutStory(sources) };
 
     const citations = sources.map(source => ({ url: source.url, title: source.title }));
     expect(validateResearchBrief(brief, selected, citations, 3)).toEqual(brief);
@@ -118,36 +94,11 @@ describe('validateResearchBrief', () => {
 
   it('names the offending source URL instead of throwing a bare Invalid URL error', () => {
     const selected = story(1);
-    const sources = [
-      {
-        title: 'Primary announcement',
-        url: selected.sourceUrl,
-        publisher: 'Vendor',
-        sourceType: 'primary' as const,
-      },
-      {
-        title: 'Broken source',
-        url: 'not-a-url',
-        publisher: 'Reporter',
-        sourceType: 'reporting' as const,
-      },
-      {
-        title: 'Technical analysis',
-        url: 'https://analysis.example/story',
-        publisher: 'Analyst',
-        sourceType: 'analysis' as const,
-      },
-    ];
+    const sources = sourcesFor(selected);
+    sources[1] = { ...sources[1], url: 'not-a-url' };
     const brief: ResearchBrief = {
       story: selected,
-      angle: 'Angle',
-      context: 'Context',
-      keyFacts: Array.from({ length: 5 }, (_, index) => ({
-        claim: `Fact ${index}`,
-        sourceUrls: [selected.sourceUrl],
-      })),
-      technicalImplications: ['Implication'],
-      openQuestions: ['Question'],
+      ...briefWithoutStory(sourcesFor(selected)),
       sources,
     };
 
@@ -174,7 +125,7 @@ describe('validateResearchBrief', () => {
   });
 });
 
-describe('research tool execution', () => {
+describe('discoverWeeklyNews', () => {
   it('accepts cited weekly discovery when the usage counter is unavailable', async () => {
     const stories = [story(1), story(2), story(3), story(4)];
     const completeJson = vi.fn().mockResolvedValue({
@@ -189,47 +140,70 @@ describe('research tool execution', () => {
     const request = completeJson.mock.calls[0][0];
     expect(request).not.toHaveProperty('toolChoice');
     expect(request.reasoningEffort).toBe('low');
+    expect(request.schema).toMatchObject({ name: 'discovery_response' });
     expect(request.tools).toContainEqual(
       expect.objectContaining({ type: 'openrouter:web_search' })
     );
     expect(completeJson).toHaveBeenCalledTimes(1);
   });
 
+  it('filters invalid candidates instead of rejecting the whole batch', async () => {
+    const stories = [story(1, { publishedAt: '2026-07-01' }), story(2), story(3), story(4)];
+    const completeJson = vi.fn().mockResolvedValue({
+      data: { stories },
+      citations: citationsFor(stories),
+      webSearchRequests: 0,
+    });
+    const client = { completeJson } as unknown as OpenRouterClient;
+
+    const result = await discoverWeeklyNews(client, [], options, now);
+
+    expect(result).toEqual(stories.slice(1));
+    expect(completeJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the best surviving batch after exhausting attempts', async () => {
+    const stories = [
+      story(1),
+      story(2, { publishedAt: '2026-07-01' }),
+      story(3, { publishedAt: '2026-07-01' }),
+      story(4, { publishedAt: '2026-07-01' }),
+    ];
+    const completeJson = vi.fn().mockResolvedValue({
+      data: { stories },
+      citations: citationsFor(stories),
+      webSearchRequests: 0,
+    });
+    const client = { completeJson } as unknown as OpenRouterClient;
+
+    const result = await discoverWeeklyNews(client, [], options, now);
+
+    expect(result).toEqual([stories[0]]);
+    expect(completeJson).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws when no candidate ever survives', async () => {
+    const stories = [story(1, { publishedAt: '2026-07-01' })];
+    const completeJson = vi.fn().mockResolvedValue({
+      data: { stories },
+      citations: citationsFor(stories),
+      webSearchRequests: 0,
+    });
+    const client = { completeJson } as unknown as OpenRouterClient;
+
+    await expect(discoverWeeklyNews(client, [], options, now)).rejects.toThrow(
+      'Could not discover valid weekly news after 3 attempts'
+    );
+    expect(completeJson).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('researchSelectedStory', () => {
   it('accepts cited deeper research when the usage counter is unavailable', async () => {
     const selected = story(1);
-    const sources = [
-      {
-        title: 'Primary announcement',
-        url: selected.sourceUrl,
-        publisher: 'Vendor',
-        sourceType: 'primary' as const,
-      },
-      {
-        title: 'Independent report',
-        url: 'https://report.example/story',
-        publisher: 'Reporter',
-        sourceType: 'reporting' as const,
-      },
-      {
-        title: 'Technical analysis',
-        url: 'https://analysis.example/story',
-        publisher: 'Analyst',
-        sourceType: 'analysis' as const,
-      },
-    ];
-    const briefWithoutStory = {
-      angle: 'A grounded engineering angle',
-      context: 'Verified context',
-      keyFacts: Array.from({ length: 5 }, (_, index) => ({
-        claim: `Fact ${index}`,
-        sourceUrls: [sources[index % sources.length].url],
-      })),
-      technicalImplications: ['Implication'],
-      openQuestions: ['Question'],
-      sources,
-    };
+    const sources = sourcesFor(selected);
     const completeJson = vi.fn().mockResolvedValue({
-      data: briefWithoutStory,
+      data: briefWithoutStory(sources),
       citations: sources.map(source => ({ url: source.url, title: source.title })),
       webSearchRequests: 0,
     });
@@ -241,6 +215,7 @@ describe('research tool execution', () => {
     const request = completeJson.mock.calls[0][0];
     expect(request.userPrompt).not.toMatch(/Return: story/);
     expect(request).not.toHaveProperty('toolChoice');
+    expect(request.schema).toMatchObject({ name: 'research_brief' });
     expect(request.tools).toContainEqual({
       type: 'openrouter:web_fetch',
       parameters: {
@@ -250,5 +225,78 @@ describe('research tool execution', () => {
       },
     });
     expect(completeJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('feeds the failed brief back into the retry prompt for repair', async () => {
+    const selected = story(1);
+    const sources = sourcesFor(selected);
+    const thinSources = sources.slice(0, 2);
+    const completeJson = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          ...briefWithoutStory(sources),
+          sources: thinSources,
+          keyFacts: Array.from({ length: 5 }, (_, index) => ({
+            claim: `Fact ${index}`,
+            sourceUrls: [thinSources[index % thinSources.length].url],
+          })),
+        },
+        citations: thinSources.map(source => ({ url: source.url, title: source.title })),
+        webSearchRequests: 0,
+      })
+      .mockResolvedValueOnce({
+        data: briefWithoutStory(sources),
+        citations: sources.map(source => ({ url: source.url, title: source.title })),
+        webSearchRequests: 0,
+      });
+    const client = { completeJson } as unknown as OpenRouterClient;
+
+    const brief = await researchSelectedStory(client, selected, 3, now);
+
+    expect(brief.story).toEqual(selected);
+    expect(completeJson).toHaveBeenCalledTimes(2);
+    const retryPrompt = completeJson.mock.calls[1][0].userPrompt;
+    expect(retryPrompt).toContain('It failed validation:');
+    expect(retryPrompt).toContain('needs at least 3 sources');
+    expect(retryPrompt).toContain('A previous attempt produced this brief');
+  });
+});
+
+describe('researchAnyStory', () => {
+  it('falls back to another candidate when one cannot be researched', async () => {
+    const storyA = story(1);
+    const storyB = story(2);
+    const sources = sourcesFor(storyB);
+    const completeJson = vi.fn().mockImplementation(async ({ userPrompt }) => {
+      if (userPrompt.includes(storyA.headline)) {
+        return { data: {}, citations: [], webSearchRequests: 0 };
+      }
+      return {
+        data: briefWithoutStory(sources),
+        citations: sources.map(source => ({ url: source.url, title: source.title })),
+        webSearchRequests: 0,
+      };
+    });
+    const client = { completeJson } as unknown as OpenRouterClient;
+
+    const brief = await researchAnyStory(client, [storyA, storyB], 3, now, () => 0);
+
+    expect(brief.story).toEqual(storyB);
+  });
+
+  it('aggregates failures when no candidate can be researched', async () => {
+    const completeJson = vi.fn().mockResolvedValue({
+      data: {},
+      citations: [],
+      webSearchRequests: 0,
+    });
+    const client = { completeJson } as unknown as OpenRouterClient;
+
+    await expect(researchAnyStory(client, [story(1), story(2)], 3, now, () => 0)).rejects.toThrow(
+      'Could not research any candidate story'
+    );
+    // 2 attempts for the first candidate (a fallback remained), 3 for the last.
+    expect(completeJson).toHaveBeenCalledTimes(5);
   });
 });

--- a/scripts/generate-blog-post.ts
+++ b/scripts/generate-blog-post.ts
@@ -1,12 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createOpenRouterClient } from './lib/openrouter';
-import {
-  categoryForStory,
-  discoverWeeklyNews,
-  researchSelectedStory,
-  selectRandomStory,
-} from './lib/research';
+import { categoryForStory, discoverWeeklyNews, researchAnyStory } from './lib/research';
 import { generateEnglishPost, generateSpanishPost } from './lib/post-generator';
 import {
   generateSlug,
@@ -22,8 +17,11 @@ const BLOG_DIR = path.join(ROOT, 'src', 'content', 'blog');
 const SLUG_OUTPUT = '/tmp/blog-generated-slug.txt';
 const RESEARCH_OUTPUT = '/tmp/blog-generated-research.md';
 
+const dryRun = process.argv.includes('--dry-run') || process.env.BLOG_DRY_RUN === '1';
+
 async function main() {
   console.log('🔄 Starting research-first blog generation...');
+  if (dryRun) console.log('🧪 Dry run: no files will be written');
 
   const config = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
   const history = JSON.parse(fs.readFileSync(HISTORY_PATH, 'utf-8'));
@@ -36,12 +34,9 @@ async function main() {
     console.log(`  ${index + 1}. ${candidate.headline} (${candidate.publishedAt})`);
   });
 
-  const selected = selectRandomStory(candidates);
+  const brief = await researchAnyStory(client, candidates, config.newsResearch.minimumSources);
+  const selected = brief.story;
   const category = categoryForStory(selected.category);
-  console.log(`🎲 Selected: ${selected.headline}`);
-
-  console.log('🔎 Investigating the selected story in depth...');
-  const brief = await researchSelectedStory(client, selected, config.newsResearch.minimumSources);
   console.log(`📚 Validated ${brief.sources.length} independent research sources`);
 
   console.log('🇺🇸 Generating grounded English post...');
@@ -81,6 +76,18 @@ async function main() {
 
   const enPath = path.join(BLOG_DIR, 'en', `${slug}.md`);
   const esPath = path.join(BLOG_DIR, 'es', `${slug}.md`);
+
+  if (dryRun) {
+    console.log(`🧪 Slug: ${slug}`);
+    console.log(`🧪 EN: "${enPost.title}" (${enPost.content.trim().split(/\s+/).length} words)`);
+    console.log(`🧪 ES: "${esPost.title}" (${esPost.content.trim().split(/\s+/).length} words)`);
+    console.log('🧪 Sources:');
+    brief.sources.forEach(source => console.log(`  - [${source.sourceType}] ${source.url}`));
+    console.log(`🧪 EN preview:\n${enPost.content.slice(0, 500)}\n...`);
+    console.log('🎉 Dry run complete — nothing written');
+    return;
+  }
+
   fs.mkdirSync(path.dirname(enPath), { recursive: true });
   fs.mkdirSync(path.dirname(esPath), { recursive: true });
   fs.writeFileSync(enPath, buildMarkdownFile(enFrontmatter, enPost.content), 'utf-8');

--- a/scripts/lib/openrouter.ts
+++ b/scripts/lib/openrouter.ts
@@ -1,6 +1,11 @@
+import type { JsonSchemaSpec } from './schemas';
+
 const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
 const MAX_EMPTY_RESPONSE_ATTEMPTS = 3;
-export const DEFAULT_OPENROUTER_MODEL = 'openai/gpt-5.2';
+const MAX_TRANSIENT_RETRIES = 3;
+const TRANSIENT_BACKOFF_MS = [5_000, 15_000, 45_000];
+const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
+export const DEFAULT_OPENROUTER_MODEL = 'deepseek/deepseek-v3.2';
 
 export interface UrlCitation {
   url: string;
@@ -21,6 +26,7 @@ interface CompletionOptions {
   temperature?: number;
   maxTokens?: number;
   reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
+  schema?: JsonSchemaSpec;
 }
 
 export interface CompletionResult<T> {
@@ -35,6 +41,7 @@ interface OpenRouterResponse {
     native_finish_reason?: string;
     message?: {
       content?: string;
+      tool_calls?: unknown[];
       annotations?: Array<{
         type?: string;
         url_citation?: { url?: string; title?: string; content?: string };
@@ -46,6 +53,7 @@ interface OpenRouterResponse {
     completion_tokens?: number;
     completion_tokens_details?: { reasoning_tokens?: number };
     server_tool_use?: { web_search_requests?: number };
+    server_tool_use_details?: { web_search_requests?: number };
   };
   error?: { message?: string };
 }
@@ -85,15 +93,41 @@ function parseJson<T>(content: string): T {
   }
 }
 
+const defaultSleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+// Textual tool-call syntax leaking into content — the model tried to call a
+// server-side tool that its provider never executed.
+const TOOL_CALL_MARKUP = /<function_calls>|<tool_call|<invoke\s|"tool_calls"\s*:/;
+
+// The model-agnostic web plugin: OpenRouter runs one search server-side and
+// injects the results, instead of relying on the model's tool calling.
+function webPluginFor(tools: OpenRouterTool[]): Record<string, unknown> {
+  const search = tools.find(tool => tool.type === 'openrouter:web_search');
+  return {
+    id: 'web',
+    engine: (search?.parameters?.engine as string) ?? 'exa',
+    max_results: (search?.parameters?.max_results as number) ?? 8,
+  };
+}
+
 export class OpenRouterClient {
+  private serverToolsUnsupported = false;
+
   constructor(
     private readonly apiKey: string,
     readonly model: string,
-    private readonly fetchImpl: typeof fetch = fetch
+    private readonly fetchImpl: typeof fetch = fetch,
+    private readonly sleep: (ms: number) => Promise<void> = defaultSleep
   ) {}
 
   async completeJson<T>(options: CompletionOptions): Promise<CompletionResult<T>> {
-    for (let attempt = 1; attempt <= MAX_EMPTY_RESPONSE_ATTEMPTS; attempt += 1) {
+    let modelAttempts = 0;
+    let transientRetries = 0;
+    let useSchema = Boolean(options.schema);
+    const wantsTools = Boolean(options.tools?.length);
+    let usePlugin = wantsTools && this.serverToolsUnsupported;
+
+    while (modelAttempts < MAX_EMPTY_RESPONSE_ATTEMPTS) {
       const response = await this.fetchImpl(OPENROUTER_URL, {
         method: 'POST',
         headers: {
@@ -108,33 +142,94 @@ export class OpenRouterClient {
             { role: 'system', content: options.systemPrompt },
             { role: 'user', content: options.userPrompt },
           ],
-          response_format: { type: 'json_object' },
-          ...(options.tools?.length ? { tools: options.tools } : {}),
-          ...(options.tools?.length && options.toolChoice
+          response_format:
+            useSchema && options.schema
+              ? {
+                  type: 'json_schema',
+                  json_schema: {
+                    name: options.schema.name,
+                    strict: true,
+                    schema: options.schema.schema,
+                  },
+                }
+              : { type: 'json_object' },
+          ...(wantsTools && !usePlugin ? { tools: options.tools } : {}),
+          ...(wantsTools && !usePlugin && options.toolChoice
             ? { tool_choice: options.toolChoice }
             : {}),
+          ...(usePlugin ? { plugins: [webPluginFor(options.tools!)] } : {}),
           ...(options.reasoningEffort ? { reasoning: { effort: options.reasoningEffort } } : {}),
           temperature: options.temperature ?? 0.3,
           max_tokens: options.maxTokens ?? 8192,
         }),
       });
 
-      const payload = (await response.json()) as OpenRouterResponse;
-      if (!response.ok) {
-        throw new Error(
-          `OpenRouter request failed (${response.status}): ${payload.error?.message ?? 'unknown error'}`
-        );
+      let payload: OpenRouterResponse;
+      try {
+        payload = (await response.json()) as OpenRouterResponse;
+      } catch {
+        payload = {};
       }
 
+      if (!response.ok) {
+        const message = payload.error?.message ?? 'unknown error';
+        if (
+          useSchema &&
+          response.status >= 400 &&
+          response.status < 500 &&
+          (response.status === 400 ||
+            /response_format|json_schema|schema|structured/i.test(message))
+        ) {
+          console.warn(
+            `⚠️ Structured outputs rejected (${response.status}: ${message}); falling back to json_object`
+          );
+          useSchema = false;
+          continue;
+        }
+        if (RETRYABLE_STATUS.has(response.status) && transientRetries < MAX_TRANSIENT_RETRIES) {
+          const retryAfter = Number(response.headers.get('retry-after'));
+          const delay =
+            Number.isFinite(retryAfter) && retryAfter > 0
+              ? retryAfter * 1000
+              : TRANSIENT_BACKOFF_MS[transientRetries];
+          transientRetries += 1;
+          console.warn(
+            `OpenRouter transient error (${response.status}: ${message}); retry ${transientRetries}/${MAX_TRANSIENT_RETRIES} in ${delay / 1000}s`
+          );
+          await this.sleep(delay);
+          continue;
+        }
+        throw new Error(`OpenRouter request failed (${response.status}): ${message}`);
+      }
+
+      modelAttempts += 1;
       const choice = payload.choices?.[0];
       const message = choice?.message;
       const finishInfo = `finish_reason=${choice?.finish_reason ?? 'unknown'} (native: ${choice?.native_finish_reason ?? 'unknown'}), completion_tokens=${payload.usage?.completion_tokens ?? '?'}, reasoning_tokens=${payload.usage?.completion_tokens_details?.reasoning_tokens ?? '?'}`;
       console.log(`📡 OpenRouter response: ${finishInfo}`);
 
+      // A response that ends in an unexecuted tool call means this provider
+      // does not run OpenRouter's server-side tools. The web plugin searches
+      // server-side regardless of the model, so switch to it — for this call
+      // and every later one on this client — without spending an attempt.
+      if (
+        wantsTools &&
+        !usePlugin &&
+        (choice?.finish_reason === 'tool_calls' || message?.tool_calls?.length)
+      ) {
+        console.warn(
+          '⚠️ Provider returned an unexecuted tool call; falling back to the web search plugin'
+        );
+        this.serverToolsUnsupported = true;
+        usePlugin = true;
+        modelAttempts -= 1;
+        continue;
+      }
+
       if (!message?.content) {
-        if (attempt < MAX_EMPTY_RESPONSE_ATTEMPTS) {
+        if (modelAttempts < MAX_EMPTY_RESPONSE_ATTEMPTS) {
           console.warn(
-            `OpenRouter returned no content (attempt ${attempt}/${MAX_EMPTY_RESPONSE_ATTEMPTS}, ${finishInfo}); retrying`
+            `OpenRouter returned no content (attempt ${modelAttempts}/${MAX_EMPTY_RESPONSE_ATTEMPTS}, ${finishInfo}); retrying`
           );
           continue;
         }
@@ -151,15 +246,58 @@ export class OpenRouterClient {
           content: annotation.url_citation!.content,
         }));
 
+      // Some models break the server-side tool loop and emit the tool call as
+      // literal text. Strict json_schema is the usual trigger, so drop it first
+      // (keeping the tools); if markup persists without the schema, the model
+      // cannot drive server tools at all — switch to the model-agnostic web
+      // plugin for this call and every later one on this client.
+      if (
+        wantsTools &&
+        TOOL_CALL_MARKUP.test(message.content) &&
+        modelAttempts < MAX_EMPTY_RESPONSE_ATTEMPTS
+      ) {
+        if (useSchema) {
+          console.warn(
+            `⚠️ Model emitted tool-call markup under json_schema (attempt ${modelAttempts}/${MAX_EMPTY_RESPONSE_ATTEMPTS}); retrying with json_object`
+          );
+          useSchema = false;
+          continue;
+        }
+        if (!usePlugin) {
+          console.warn(
+            `⚠️ Model emitted tool-call markup instead of executing server-side tools (attempt ${modelAttempts}/${MAX_EMPTY_RESPONSE_ATTEMPTS}); falling back to the web search plugin`
+          );
+          this.serverToolsUnsupported = true;
+          usePlugin = true;
+          continue;
+        }
+      }
+
+      // Some providers drop tool citations under strict schema mode; a response
+      // whose sources cannot be verified is useless downstream, so spend one
+      // attempt to get a cited response without the schema instead.
+      if (
+        useSchema &&
+        wantsTools &&
+        citations.length === 0 &&
+        modelAttempts < MAX_EMPTY_RESPONSE_ATTEMPTS
+      ) {
+        console.warn(
+          `⚠️ Structured output carried no citations (attempt ${modelAttempts}/${MAX_EMPTY_RESPONSE_ATTEMPTS}); retrying with json_object`
+        );
+        useSchema = false;
+        continue;
+      }
+
       let data: T;
       try {
         data = parseJson<T>(message.content);
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
         const snippet = message.content.slice(0, 200);
-        if (attempt < MAX_EMPTY_RESPONSE_ATTEMPTS) {
+        if (modelAttempts < MAX_EMPTY_RESPONSE_ATTEMPTS) {
           console.warn(
-            `OpenRouter returned unparseable JSON (attempt ${attempt}/${MAX_EMPTY_RESPONSE_ATTEMPTS}): ${reason}; content starts with: ${snippet}`
+            `OpenRouter returned unparseable JSON (attempt ${modelAttempts}/${MAX_EMPTY_RESPONSE_ATTEMPTS}): ${reason}; content starts with: ${snippet}`
           );
           continue;
         }
@@ -172,7 +310,10 @@ export class OpenRouterClient {
       return {
         data,
         citations,
-        webSearchRequests: payload.usage?.server_tool_use?.web_search_requests ?? 0,
+        webSearchRequests:
+          payload.usage?.server_tool_use?.web_search_requests ??
+          payload.usage?.server_tool_use_details?.web_search_requests ??
+          0,
       };
     }
 

--- a/scripts/lib/post-generator.ts
+++ b/scripts/lib/post-generator.ts
@@ -1,4 +1,7 @@
 import type { OpenRouterClient } from './openrouter';
+import { coerceString, coerceStringArray } from './repair';
+import { GENERATED_POST_SCHEMA } from './schemas';
+import { isHttpsUrl, normalizeUrl } from './urls';
 import type { GeneratedPost, ResearchBrief } from './types';
 
 interface GenerationRules {
@@ -17,6 +20,31 @@ function markdownUrls(content: string): string[] {
   return [...content.matchAll(/\[[^\]]+\]\((https:\/\/[^\s)]+)\)/g)].map(match => match[1]);
 }
 
+// Prompt a ceiling below the hard validation cap: models routinely overshoot
+// their target by a few percent, and Spanish adaptations run longer than the
+// English source they are based on.
+function promptWordCeiling(rules: GenerationRules): number {
+  return Math.max(rules.wordsMin, Math.round(rules.wordsMax * 0.9));
+}
+
+function repairGeneratedPost(raw: unknown): GeneratedPost {
+  const record = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+  const faq = (Array.isArray(record.faq) ? record.faq : [])
+    .map(item => {
+      const entry = item && typeof item === 'object' ? (item as Record<string, unknown>) : {};
+      return { question: coerceString(entry.question), answer: coerceString(entry.answer) };
+    })
+    .filter(item => item.question && item.answer);
+
+  return {
+    title: coerceString(record.title),
+    content: typeof record.content === 'string' ? record.content : coerceString(record.content),
+    tags: coerceStringArray(record.tags).map(tag => tag.toLowerCase()),
+    summary: coerceString(record.summary),
+    faq,
+  };
+}
+
 function validateGeneratedPost(
   post: GeneratedPost,
   brief: ResearchBrief,
@@ -24,29 +52,43 @@ function validateGeneratedPost(
 ): GeneratedPost {
   if (!post?.title?.trim() || !post.content?.trim())
     throw new Error('Generated post is incomplete');
+
+  // Collect every problem so one retry can fix them all; reporting only the
+  // first lets the model ping-pong between fixing one flaw and reintroducing another.
+  const issues: string[] = [];
   if (!Array.isArray(post.tags) || post.tags.length < 3 || post.tags.length > 5) {
-    throw new Error('Generated post must have three to five tags');
+    issues.push('Generated post must have three to five tags');
   }
   if (post.summary.length < 120 || post.summary.length > 160) {
-    throw new Error('Generated summary must be 120–160 characters');
+    issues.push('Generated summary must be 120–160 characters');
   }
   if (!Array.isArray(post.faq) || post.faq.length < 3 || post.faq.length > 5) {
-    throw new Error('Generated post must have three to five FAQ items');
+    issues.push('Generated post must have three to five FAQ items');
   }
 
   const count = wordCount(post.content);
   if (count < rules.wordsMin || count > rules.wordsMax) {
-    throw new Error(
-      `Generated post has ${count} words; expected ${rules.wordsMin}–${rules.wordsMax}`
+    const adjustment =
+      count > rules.wordsMax
+        ? `remove at least ${count - rules.wordsMax} words`
+        : `add at least ${rules.wordsMin - count} words`;
+    issues.push(
+      `Generated post has ${count} words; expected ${rules.wordsMin}–${rules.wordsMax} (${adjustment})`
     );
   }
 
-  const allowedUrls = new Set(brief.sources.map(source => source.url));
+  const allowedUrls = new Set(brief.sources.map(source => normalizeUrl(source.url)));
   const citedUrls = markdownUrls(post.content);
-  if (new Set(citedUrls).size < 2) throw new Error('Generated post must cite at least two sources');
-  for (const url of citedUrls) {
-    if (!allowedUrls.has(url)) throw new Error(`Generated post cites an unresearched URL: ${url}`);
+  for (const url of new Set(citedUrls)) {
+    if (!isHttpsUrl(url) || !allowedUrls.has(normalizeUrl(url))) {
+      issues.push(`Generated post cites an unresearched URL: ${url}`);
+    }
   }
+  if (new Set(citedUrls.map(url => (isHttpsUrl(url) ? normalizeUrl(url) : url))).size < 2) {
+    issues.push('Generated post must cite at least two sources');
+  }
+
+  if (issues.length > 0) throw new Error(issues.join('; '));
 
   return post;
 }
@@ -59,29 +101,35 @@ async function generateWithRetry(
   rules: GenerationRules
 ): Promise<GeneratedPost> {
   let validationError = '';
+  let lastPostJson = '';
+  const maxAttempts = 3;
 
-  for (let attempt = 1; attempt <= 2; attempt += 1) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const response = await client.completeJson<GeneratedPost>({
       systemPrompt,
       userPrompt: `${userPrompt}${
         validationError
-          ? `\n\nYour previous response failed validation: ${validationError}. Correct every issue.`
+          ? `\n\nYour previous attempt produced this post JSON (possibly truncated):\n${lastPostJson}\nIt failed validation: ${validationError}\nRepair it: keep everything that was correct and fix only the listed problems.`
           : ''
       }`,
       temperature: 0.6,
       maxTokens: 16000,
       reasoningEffort: 'low',
+      schema: GENERATED_POST_SCHEMA,
     });
 
     try {
-      return validateGeneratedPost(response.data, brief, rules);
+      return validateGeneratedPost(repairGeneratedPost(response.data), brief, rules);
     } catch (error) {
       validationError = error instanceof Error ? error.message : String(error);
+      lastPostJson = JSON.stringify(response.data).slice(0, 6000);
       console.warn(`⚠️ Generation attempt ${attempt} failed validation: ${validationError}`);
     }
   }
 
-  throw new Error(`Could not generate a valid post after two attempts: ${validationError}`);
+  throw new Error(
+    `Could not generate a valid post after ${maxAttempts} attempts: ${validationError}`
+  );
 }
 
 export async function generateEnglishPost(
@@ -102,7 +150,7 @@ Grounding rules:
 - Do not reproduce long passages from sources; synthesize in your own words
 
 Writing rules:
-- Write between ${rules.wordsMin} and ${rules.wordsMax} words
+- Write between ${rules.wordsMin} and ${promptWordCeiling(rules)} words; never exceed ${promptWordCeiling(rules)} words
 - Use markdown with ## for main sections and ### for subsections
 - Include practical technical examples only when supported by the research
 - Do NOT include the title as an h1—it is rendered separately
@@ -133,11 +181,15 @@ export async function generateSpanishPost(
   brief: ResearchBrief,
   rules: GenerationRules
 ): Promise<GeneratedPost> {
+  const englishWords = wordCount(englishPost.content);
+  const spanishCeiling = Math.max(rules.wordsMin, Math.min(promptWordCeiling(rules), englishWords));
   const systemPrompt = `You are ${rules.persona}. Adapt the supplied English post into natural Spanish.
 This is not a literal translation. Preserve its technical accuracy, nuance, code, and inline source links.
 Do not introduce facts or URLs that are absent from the English post and research brief.
 Keep the same SEO/AEO structure, question-based H2 headings, Key Takeaways section, and FAQ section.
-Write between ${rules.wordsMin} and ${rules.wordsMax} words. The summary must be 120–160 Spanish characters.
+Write between ${rules.wordsMin} and ${spanishCeiling} words; never exceed ${spanishCeiling} words.
+The English post is ${englishWords} words. Spanish prose runs longer than English, so condense while adapting rather than translating sentence by sentence — your Spanish version must not be longer than the English post.
+The summary must be 120–160 Spanish characters.
 Do not add a Sources section; the page renders the structured sources separately.
 
 Return JSON with title, content, tags (3–5 lowercase Spanish tags), summary, and faq (3–5 {question, answer} objects).`;

--- a/scripts/lib/repair.ts
+++ b/scripts/lib/repair.ts
@@ -1,0 +1,233 @@
+import type { UrlCitation } from './openrouter';
+import { citationUrls, isHttpsUrl, normalizeUrl } from './urls';
+import {
+  NEWS_CATEGORIES,
+  type BlogHistoryEntry,
+  type NewsCandidate,
+  type NewsCategory,
+  type ResearchBrief,
+  type ResearchFact,
+  type ResearchOptions,
+  type ResearchSource,
+} from './types';
+
+export function coerceString(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return value.map(coerceString).filter(Boolean).join('\n\n');
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).map(coerceString).filter(Boolean).join('\n\n');
+  }
+  return '';
+}
+
+export function coerceStringArray(value: unknown): string[] {
+  if (typeof value === 'string') return value.trim() ? [value.trim()] : [];
+  if (Array.isArray(value)) return value.map(coerceString).filter(Boolean);
+  return [];
+}
+
+const SOURCE_TYPE_SYNONYMS: Record<string, ResearchSource['sourceType']> = {
+  primary: 'primary',
+  official: 'primary',
+  announcement: 'primary',
+  reporting: 'reporting',
+  report: 'reporting',
+  news: 'reporting',
+  analysis: 'analysis',
+  commentary: 'analysis',
+  opinion: 'analysis',
+};
+
+// Defaults to 'reporting' so repair can never fabricate the mandatory primary source.
+export function coerceSourceType(value: unknown): ResearchSource['sourceType'] {
+  if (typeof value !== 'string') return 'reporting';
+  return SOURCE_TYPE_SYNONYMS[value.trim().toLowerCase()] ?? 'reporting';
+}
+
+export interface RejectedCandidate {
+  story: unknown;
+  reason: string;
+}
+
+function startOfLookbackWindow(now: Date, lookbackDays: number): Date {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  start.setUTCDate(start.getUTCDate() - (lookbackDays - 1));
+  return start;
+}
+
+export function repairNewsCandidates(
+  raw: unknown,
+  citations: UrlCitation[],
+  history: BlogHistoryEntry[],
+  now: Date,
+  options: ResearchOptions
+): { valid: NewsCandidate[]; rejected: RejectedCandidate[] } {
+  const valid: NewsCandidate[] = [];
+  const rejected: RejectedCandidate[] = [];
+  const earliest = startOfLookbackWindow(now, options.lookbackDays).getTime();
+  const latest = now.getTime() + 24 * 60 * 60 * 1000;
+  const cited = citationUrls(citations);
+  const seen = new Set<string>();
+  const pastUrls = new Set(
+    history
+      .flatMap(item => item.sourceUrls ?? [])
+      .filter(isHttpsUrl)
+      .map(normalizeUrl)
+  );
+  const pastTopics = new Set(history.map(item => item.topic.trim().toLowerCase()));
+
+  for (const rawStory of Array.isArray(raw) ? raw : []) {
+    if (!rawStory || typeof rawStory !== 'object') {
+      rejected.push({ story: rawStory, reason: 'Story is not an object' });
+      continue;
+    }
+    const record = rawStory as Record<string, unknown>;
+    const story: NewsCandidate = {
+      headline: coerceString(record.headline),
+      summary: coerceString(record.summary),
+      category: coerceString(record.category).toLowerCase() as NewsCategory,
+      publishedAt: coerceString(record.publishedAt),
+      sourceUrl: coerceString(record.sourceUrl),
+      sourceName: coerceString(record.sourceName),
+      whyItMatters: coerceString(record.whyItMatters),
+    };
+    const label = story.headline || 'Unnamed story';
+
+    if (!NEWS_CATEGORIES.includes(story.category)) {
+      rejected.push({
+        story: rawStory,
+        reason: `${label}: unsupported category "${story.category}"`,
+      });
+      continue;
+    }
+    if (!isHttpsUrl(story.sourceUrl)) {
+      rejected.push({ story: rawStory, reason: `${label}: missing a valid HTTPS source URL` });
+      continue;
+    }
+    const normalizedUrl = normalizeUrl(story.sourceUrl);
+    if (seen.has(normalizedUrl)) {
+      rejected.push({ story: rawStory, reason: `${label}: duplicate source URL in this batch` });
+      continue;
+    }
+    if (pastUrls.has(normalizedUrl)) {
+      rejected.push({ story: rawStory, reason: `${label}: source URL already covered` });
+      continue;
+    }
+    if (pastTopics.has(story.headline.trim().toLowerCase())) {
+      rejected.push({ story: rawStory, reason: `${label}: headline already covered` });
+      continue;
+    }
+    if (!cited.has(normalizedUrl)) {
+      rejected.push({
+        story: rawStory,
+        reason: `${label}: source was not returned by web research (${story.sourceUrl})`,
+      });
+      continue;
+    }
+    const publishedAt = Date.parse(story.publishedAt);
+    if (!Number.isFinite(publishedAt) || publishedAt < earliest || publishedAt > latest) {
+      rejected.push({
+        story: rawStory,
+        reason: `${label}: outside the ${options.lookbackDays}-day window (${story.publishedAt})`,
+      });
+      continue;
+    }
+    if (!story.headline || !story.summary || !story.whyItMatters) {
+      rejected.push({
+        story: rawStory,
+        reason: `${label}: missing headline, summary, or relevance explanation`,
+      });
+      continue;
+    }
+
+    seen.add(normalizedUrl);
+    valid.push(story);
+  }
+
+  return { valid, rejected };
+}
+
+export function repairResearchBrief(
+  raw: unknown,
+  selectedStory: NewsCandidate,
+  citations: UrlCitation[]
+): { brief: ResearchBrief; dropped: string[] } {
+  const record = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+  const dropped: string[] = [];
+  const cited = citationUrls(citations);
+
+  const sources: ResearchSource[] = [];
+  const canonicalByNormalized = new Map<string, string>();
+  for (const rawSource of Array.isArray(record.sources) ? record.sources : []) {
+    if (!rawSource || typeof rawSource !== 'object') {
+      dropped.push('source that is not an object');
+      continue;
+    }
+    const entry = rawSource as Record<string, unknown>;
+    const url = coerceString(entry.url);
+    if (!isHttpsUrl(url)) {
+      dropped.push(`source without a valid HTTPS URL: ${url || 'none'}`);
+      continue;
+    }
+    const normalized = normalizeUrl(url);
+    if (!cited.has(normalized)) {
+      dropped.push(`uncited source: ${url}`);
+      continue;
+    }
+    if (canonicalByNormalized.has(normalized)) {
+      dropped.push(`duplicate source: ${url}`);
+      continue;
+    }
+    canonicalByNormalized.set(normalized, url);
+    const publishedAt = coerceString(entry.publishedAt);
+    sources.push({
+      title: coerceString(entry.title) || url,
+      url,
+      publisher: coerceString(entry.publisher) || new URL(url).hostname.replace(/^www\./, ''),
+      ...(publishedAt ? { publishedAt } : {}),
+      sourceType: coerceSourceType(entry.sourceType),
+    });
+  }
+
+  const keyFacts: ResearchFact[] = [];
+  for (const rawFact of Array.isArray(record.keyFacts) ? record.keyFacts : []) {
+    if (!rawFact || typeof rawFact !== 'object') {
+      dropped.push('fact that is not an object');
+      continue;
+    }
+    const entry = rawFact as Record<string, unknown>;
+    const claim = coerceString(entry.claim);
+    const sourceUrls = [
+      ...new Set(
+        coerceStringArray(entry.sourceUrls)
+          .filter(isHttpsUrl)
+          .map(url => canonicalByNormalized.get(normalizeUrl(url)))
+          .filter((url): url is string => Boolean(url))
+      ),
+    ];
+    if (!claim) {
+      dropped.push('fact without a claim');
+      continue;
+    }
+    if (sourceUrls.length === 0) {
+      dropped.push(`fact without surviving sources: ${claim.slice(0, 80)}`);
+      continue;
+    }
+    keyFacts.push({ claim, sourceUrls });
+  }
+
+  const brief: ResearchBrief = {
+    story: selectedStory,
+    angle: coerceString(record.angle),
+    context: coerceString(record.context),
+    keyFacts,
+    technicalImplications: coerceStringArray(record.technicalImplications),
+    openQuestions: coerceStringArray(record.openQuestions),
+    sources,
+  };
+
+  return { brief, dropped };
+}

--- a/scripts/lib/research.ts
+++ b/scripts/lib/research.ts
@@ -1,106 +1,27 @@
 import { randomInt } from 'node:crypto';
 import type { OpenRouterClient, UrlCitation } from './openrouter';
+import { repairNewsCandidates, repairResearchBrief } from './repair';
+import { DISCOVERY_SCHEMA, RESEARCH_BRIEF_SCHEMA } from './schemas';
+import { citationUrls, isHttpsUrl, normalizeUrl } from './urls';
 import {
   NEWS_CATEGORIES,
+  type BlogHistoryEntry,
   type NewsCandidate,
   type ResearchBrief,
+  type ResearchOptions,
   type ResearchSource,
 } from './types';
-
-interface BlogHistoryEntry {
-  topic: string;
-  sourceUrls?: string[];
-}
 
 interface DiscoveryResponse {
   stories: NewsCandidate[];
 }
 
-interface ResearchOptions {
-  lookbackDays: number;
-  candidateCount: number;
-  minimumSources: number;
-  subjects: string[];
-}
-
 const MAX_VALIDATION_ATTEMPTS = 3;
-
-function isHttpsUrl(value: string): boolean {
-  try {
-    return new URL(value).protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
-function normalizeUrl(value: string): string {
-  const url = new URL(value);
-  url.hash = '';
-  url.search = '';
-  return url.toString().replace(/\/$/, '');
-}
-
-function startOfLookbackWindow(now: Date, lookbackDays: number): Date {
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  start.setUTCDate(start.getUTCDate() - (lookbackDays - 1));
-  return start;
-}
-
-function citationUrls(citations: UrlCitation[]): Set<string> {
-  return new Set(citations.filter(c => isHttpsUrl(c.url)).map(c => normalizeUrl(c.url)));
-}
-
-export function validateNewsCandidates(
-  stories: NewsCandidate[],
-  citations: UrlCitation[],
-  history: BlogHistoryEntry[],
-  now: Date,
-  options: ResearchOptions
-): NewsCandidate[] {
-  if (!Array.isArray(stories) || stories.length !== options.candidateCount) {
-    throw new Error(`Expected exactly ${options.candidateCount} news stories`);
-  }
-
-  const earliest = startOfLookbackWindow(now, options.lookbackDays).getTime();
-  const latest = now.getTime() + 24 * 60 * 60 * 1000;
-  const seen = new Set<string>();
-  const cited = citationUrls(citations);
-  const pastUrls = new Set(
-    history
-      .flatMap(item => item.sourceUrls ?? [])
-      .filter(isHttpsUrl)
-      .map(normalizeUrl)
-  );
-  const pastTopics = new Set(history.map(item => item.topic.trim().toLowerCase()));
-
-  for (const story of stories) {
-    if (!NEWS_CATEGORIES.includes(story.category)) {
-      throw new Error(`Unsupported news category: ${story.category}`);
-    }
-    if (!isHttpsUrl(story.sourceUrl)) throw new Error('Every story needs a valid HTTPS source');
-
-    const normalizedUrl = normalizeUrl(story.sourceUrl);
-    if (seen.has(normalizedUrl)) throw new Error('News stories must have distinct source URLs');
-    if (pastUrls.has(normalizedUrl)) throw new Error('A discovered story was already covered');
-    if (pastTopics.has(story.headline.trim().toLowerCase())) {
-      throw new Error('A discovered headline was already covered');
-    }
-    if (!cited.has(normalizedUrl)) {
-      throw new Error(`Story source was not returned by web research: ${story.sourceUrl}`);
-    }
-
-    const publishedAt = Date.parse(story.publishedAt);
-    if (!Number.isFinite(publishedAt) || publishedAt < earliest || publishedAt > latest) {
-      throw new Error(`Story is outside the ${options.lookbackDays}-day window: ${story.headline}`);
-    }
-    if (!story.headline.trim() || !story.summary.trim() || !story.whyItMatters.trim()) {
-      throw new Error('Every story needs a headline, summary, and relevance explanation');
-    }
-    seen.add(normalizedUrl);
-  }
-
-  return stories;
-}
+// A batch this size keeps some randomness in story selection; below it we keep
+// retrying, but a smaller non-empty batch still beats a failed run.
+const PREFERRED_MIN_CANDIDATES = 2;
+// When other candidates remain as fallbacks, give each story fewer attempts.
+const FALLBACK_STORY_ATTEMPTS = 2;
 
 export function selectRandomStory(
   stories: NewsCandidate[],
@@ -131,6 +52,7 @@ export async function discoverWeeklyNews(
   now = new Date()
 ): Promise<NewsCandidate[]> {
   let lastError = '';
+  let bestBatch: NewsCandidate[] = [];
 
   for (let attempt = 1; attempt <= MAX_VALIDATION_ATTEMPTS; attempt += 1) {
     const response = await client.completeJson<DiscoveryResponse>({
@@ -162,24 +84,36 @@ Return each story with: headline, summary, category (one of ${NEWS_CATEGORIES.jo
       ],
       maxTokens: 16000,
       reasoningEffort: 'low',
+      schema: DISCOVERY_SCHEMA,
     });
 
     console.log(
       `🔍 Discovery attempt ${attempt}: ${response.webSearchRequests} web search request(s), ${response.citations.length} citation(s)`
     );
 
-    try {
-      return validateNewsCandidates(
-        response.data.stories,
-        response.citations,
-        history,
-        now,
-        options
-      );
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-      console.warn(`⚠️ Discovery attempt ${attempt} failed validation: ${lastError}`);
-    }
+    const { valid, rejected } = repairNewsCandidates(
+      response.data?.stories,
+      response.citations,
+      history,
+      now,
+      options
+    );
+    rejected.forEach(item => console.warn(`⚠️ Dropped candidate: ${item.reason}`));
+
+    if (valid.length >= Math.min(PREFERRED_MIN_CANDIDATES, options.candidateCount)) return valid;
+
+    if (valid.length > bestBatch.length) bestBatch = valid;
+    lastError = `only ${valid.length} of ${options.candidateCount} candidates survived validation${
+      rejected.length ? `: ${rejected.map(item => item.reason).join('; ')}` : ''
+    }`;
+    console.warn(`⚠️ Discovery attempt ${attempt} came up short: ${lastError}`);
+  }
+
+  if (bestBatch.length > 0) {
+    console.warn(
+      `⚠️ Proceeding with ${bestBatch.length} validated candidate(s) after ${MAX_VALIDATION_ATTEMPTS} attempts`
+    );
+    return bestBatch;
   }
 
   throw new Error(
@@ -254,11 +188,13 @@ export async function researchSelectedStory(
   client: OpenRouterClient,
   story: NewsCandidate,
   minimumSources: number,
-  now = new Date()
+  now = new Date(),
+  attempts = MAX_VALIDATION_ATTEMPTS
 ): Promise<ResearchBrief> {
   let lastError = '';
+  let lastBriefJson = '';
 
-  for (let attempt = 1; attempt <= MAX_VALIDATION_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const response = await client.completeJson<ResearchBrief>({
       systemPrompt: `You are a technical research analyst. Use web search and web fetch extensively before answering.
 Verify claims against the fetched pages. Separate facts from interpretation. Prefer primary material and corroborate it with independent reporting or analysis.
@@ -270,7 +206,15 @@ ${JSON.stringify(story, null, 2)}
 Read the original source, find the best primary source, and find independent sources that add technical context or corroboration.
 Use at least ${minimumSources} sources from different domains, including at least one primary source.
 Do not use social posts, search-result pages, scraped copies, or sources you did not actually read.
-${lastError ? `The previous result failed validation: ${lastError}\nCorrect every issue.` : ''}
+${
+  lastError
+    ? `A previous attempt produced this brief (possibly truncated):
+${lastBriefJson}
+It failed validation: ${lastError}
+Repair it: keep everything that was correct and fix only the listed problems.
+If a source could not be verified by your web tools, replace it with one you actually searched or fetched in this conversation.`
+    : ''
+}
 
 Return: angle, context, at least five keyFacts ({claim, sourceUrls}), technicalImplications, openQuestions, and sources ({title, url, publisher, publishedAt when known, sourceType as primary/reporting/analysis}).`,
       tools: [
@@ -292,30 +236,63 @@ Return: angle, context, at least five keyFacts ({claim, sourceUrls}), technicalI
           },
         },
       ],
-      maxTokens: 16000,
+      maxTokens: 24000,
       reasoningEffort: 'low',
+      schema: RESEARCH_BRIEF_SCHEMA,
     });
 
     console.log(
       `🔍 Research attempt ${attempt}: ${response.webSearchRequests} web search request(s), ${response.citations.length} citation(s)`
     );
 
+    const { brief, dropped } = repairResearchBrief(response.data, story, response.citations);
+    dropped.forEach(reason => console.warn(`⚠️ Dropped from brief: ${reason}`));
+
     try {
-      return validateResearchBrief(
-        { ...response.data, story },
-        story,
-        response.citations,
-        minimumSources
-      );
+      return validateResearchBrief(brief, story, response.citations, minimumSources);
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
+      lastBriefJson = JSON.stringify(response.data).slice(0, 4000);
       console.warn(`⚠️ Research attempt ${attempt} failed validation: ${lastError}`);
     }
   }
 
   throw new Error(
-    `Could not build a valid research brief after ${MAX_VALIDATION_ATTEMPTS} attempts: ${lastError}`
+    `Could not build a valid research brief after ${attempts} attempts: ${lastError}`
   );
+}
+
+export async function researchAnyStory(
+  client: OpenRouterClient,
+  candidates: NewsCandidate[],
+  minimumSources: number,
+  now = new Date(),
+  pickIndex: (length: number) => number = length => randomInt(length)
+): Promise<ResearchBrief> {
+  const remaining = [...candidates];
+  const failures: string[] = [];
+
+  while (remaining.length > 0) {
+    const story = selectRandomStory(remaining, pickIndex);
+    remaining.splice(remaining.indexOf(story), 1);
+    console.log(`🎲 Selected: ${story.headline}`);
+    console.log('🔎 Investigating the selected story in depth...');
+
+    const attempts = remaining.length > 0 ? FALLBACK_STORY_ATTEMPTS : MAX_VALIDATION_ATTEMPTS;
+    try {
+      return await researchSelectedStory(client, story, minimumSources, now, attempts);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failures.push(`${story.headline}: ${message}`);
+      if (remaining.length > 0) {
+        console.warn(
+          `⚠️ Story could not be researched; falling back to another candidate: ${message}`
+        );
+      }
+    }
+  }
+
+  throw new Error(`Could not research any candidate story:\n${failures.join('\n')}`);
 }
 
 export function categoryForStory(category: NewsCandidate['category']): string {

--- a/scripts/lib/schemas.ts
+++ b/scripts/lib/schemas.ts
@@ -1,0 +1,117 @@
+import { NEWS_CATEGORIES } from './types';
+
+// Structural constraints only (types, enums, required). Counts and lengths are
+// deliberately left to the repair/validation layer: strict-mode support for
+// keywords like minItems is inconsistent across providers, and a leaner schema
+// maximizes the chance json_schema is accepted alongside the web tools.
+
+export interface JsonSchemaSpec {
+  name: string;
+  schema: Record<string, unknown>;
+}
+
+export const DISCOVERY_SCHEMA: JsonSchemaSpec = {
+  name: 'discovery_response',
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['stories'],
+    properties: {
+      stories: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: [
+            'headline',
+            'summary',
+            'category',
+            'publishedAt',
+            'sourceUrl',
+            'sourceName',
+            'whyItMatters',
+          ],
+          properties: {
+            headline: { type: 'string' },
+            summary: { type: 'string' },
+            category: { type: 'string', enum: [...NEWS_CATEGORIES] },
+            publishedAt: { type: 'string' },
+            sourceUrl: { type: 'string' },
+            sourceName: { type: 'string' },
+            whyItMatters: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+};
+
+// No "story" property: the selected story is injected server-side after parsing.
+export const RESEARCH_BRIEF_SCHEMA: JsonSchemaSpec = {
+  name: 'research_brief',
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['angle', 'context', 'keyFacts', 'technicalImplications', 'openQuestions', 'sources'],
+    properties: {
+      angle: { type: 'string' },
+      context: { type: 'string' },
+      keyFacts: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['claim', 'sourceUrls'],
+          properties: {
+            claim: { type: 'string' },
+            sourceUrls: { type: 'array', items: { type: 'string' } },
+          },
+        },
+      },
+      technicalImplications: { type: 'array', items: { type: 'string' } },
+      openQuestions: { type: 'array', items: { type: 'string' } },
+      sources: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['title', 'url', 'publisher', 'publishedAt', 'sourceType'],
+          properties: {
+            title: { type: 'string' },
+            url: { type: 'string' },
+            publisher: { type: 'string' },
+            publishedAt: { type: ['string', 'null'] },
+            sourceType: { type: 'string', enum: ['primary', 'reporting', 'analysis'] },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const GENERATED_POST_SCHEMA: JsonSchemaSpec = {
+  name: 'generated_post',
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['title', 'content', 'tags', 'summary', 'faq'],
+    properties: {
+      title: { type: 'string' },
+      content: { type: 'string' },
+      tags: { type: 'array', items: { type: 'string' } },
+      summary: { type: 'string' },
+      faq: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['question', 'answer'],
+          properties: {
+            question: { type: 'string' },
+            answer: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+};

--- a/scripts/lib/types.ts
+++ b/scripts/lib/types.ts
@@ -40,6 +40,18 @@ export interface ResearchBrief {
   sources: ResearchSource[];
 }
 
+export interface BlogHistoryEntry {
+  topic: string;
+  sourceUrls?: string[];
+}
+
+export interface ResearchOptions {
+  lookbackDays: number;
+  candidateCount: number;
+  minimumSources: number;
+  subjects: string[];
+}
+
 export interface FaqItem {
   question: string;
   answer: string;

--- a/scripts/lib/urls.ts
+++ b/scripts/lib/urls.ts
@@ -1,0 +1,20 @@
+import type { UrlCitation } from './openrouter';
+
+export function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeUrl(value: string): string {
+  const url = new URL(value);
+  url.hash = '';
+  url.search = '';
+  return url.toString().replace(/\/$/, '');
+}
+
+export function citationUrls(citations: UrlCitation[]): Set<string> {
+  return new Set(citations.filter(c => isHttpsUrl(c.url)).map(c => normalizeUrl(c.url)));
+}


### PR DESCRIPTION
## Problem

The research-first blog pipeline (#126) failed **every run** since its introduction, despite five hotfix PRs (#127–#133). Root cause was the design: each attempt had to pass ~10 strict validators in one shot, was rejected wholesale on any single flaw, and retried by regenerating from scratch — so every retry could fail for a brand-new reason.

## Fix: repair-then-validate

All quality gates stay byte-identical (cited-only sources, 3+ sources on distinct domains, 5+ facts, primary source, 7-day freshness, 1200–2000 words, EN+ES). What changed is everything around them:

- **`scripts/lib/repair.ts`** — deterministically coerces malformed fields and *discards* uncited sources + dependent facts before the unchanged validators run. Repair removes unverified material, never admits it, and can never fabricate the mandatory primary source.
- **Candidate fallback** — `researchAnyStory` tries other discovered stories when one can't produce a valid brief; discovery filters invalid candidates instead of rejecting the batch.
- **Client hardening** (`openrouter.ts`) — transient HTTP retries (408/429/5xx, backoff), strict `json_schema` structured outputs (`schemas.ts`) with never-worse fallback to `json_object`, and detection of broken server-side tool execution (textual tool-call markup, unexecuted `tool_calls`) with a sticky fallback to the model-agnostic web plugin.
- **Smarter retries** — failed JSON is fed back for repair instead of regenerating; post validation reports *all* problems at once instead of ping-ponging on one at a time.
- **Word-count convergence** — prompts target 90% of the cap, Spanish length is anchored to the English word count, and length errors say exactly how many words to cut.
- **Default model** → `deepseek/deepseek-v3.2` (verified: valid slug, supports structured outputs/tools/reasoning, 164k context).
- **`--dry-run` mode** runs the full pipeline without writing files; workflow gets `timeout-minutes: 30`.

## Verification

- 468 unit tests pass (55+ new), lint clean, build green.
- Live end-to-end dry run on `deepseek/deepseek-v3.2` succeeded, exercising the full fallback chain (schema drop → plugin switch → validation recovery on both EN and ES posts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)